### PR TITLE
Add SRF module enhancements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm", "cython", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from Cython.Build import cythonize
 import numpy as np
+from Cython.Build import cythonize
 from setuptools import Extension, setup
 
 extensions = [

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from Cython.Build import cythonize
+import numpy as np
+from setuptools import Extension, setup
+
+extensions = [
+    Extension(
+        "source_modelling.srf_reader",
+        ["source_modelling/srf_reader.pyx"],
+        include_dirs=[np.get_include()],
+    ),
+]
+
+setup(
+    name="source_modelling",
+    ext_modules=cythonize(extensions),
+)

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -104,8 +104,46 @@ class SrfFile:
         The version of this SrfFile
     header : pd.DataFrame
         A list of SrfSegment objects representing the header of the SRF file.
+        The columns of the header are:
+
+        - elon: The centre longitude of the plane.
+        - elot: The centre latitude of the plane.
+        - nstk: The number of patches along strike for the plane.
+        - ndip: The number of patches along dip for the plane.
+        - len: The length of the plane (in km).
+        - wid: The width of the plane (in km).
+        - stk: The plane strike.
+        - dip: The plane dip.
+        - dtop: The top of the plane.
+        - dbottom: The bottom of the plane.
+        - shyp: The hypocentre location in strike coordinates.
+        - dhyp: The hypocentre location in dip coordinates.
+
+
     points : pd.DataFrame
-        A list of SrfPoint objects representing the points in the SRF file.
+        A list of SrfPoint objects representing the points in the SRF
+        file. The columns of the points dataframe are:
+
+        - lon: longitude of the patch.
+        - lat: latitude of the patch.
+        - dep: depth of the patch (in kilometres).
+        - stk: local strike.
+        - dip: local dip.
+        - area: area of the patch (in cm^2).
+        - tinit: initial rupture time for this patch (in seconds).
+        - dt: the timestep for all slipt* columns (in seconds).
+        - rake: local rake.
+        - slip1: total slip in the first component.
+        - slip2: total slip in the second component.
+        - slip3: total slip in the third component.
+        - slipt1: slip in the first component over time.
+        - slipt2: slip in the second component over time.
+        - slipt3: slip in the third component over time.
+        - slipt: total slip over time.
+        - slip: total slip.
+
+        The final two columns are computed from the SRF and are not saved to
+        disk. See the linked documentation on the SRF format for more details.
     """
 
     version: str

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -162,7 +162,7 @@ class SrfFile:
 
     @property
     def slip(self):
-        """csr_array: sparse array representing slip in all components"""
+        """csr_array: sparse array representing slip in all components."""
         slip_array = self.slipt1_array.power(2)
         if self.slipt2_array:
             slip_array += self.slipt2_array.power(2)
@@ -366,7 +366,7 @@ def write_srf_point(srf_file: TextIO, srf: SrfFile, point: pd.Series) -> None:
     point : pd.Series
         The point to write.
     """
-    index = point.name
+    index = int(point["point_index"])
     slipt1 = (
         srf.slipt1_array.data[
             srf.slipt1_array.indptr[index] : srf.slipt1_array.indptr[index + 1]
@@ -429,6 +429,9 @@ def write_srf(srf_ffp: Path, srf: SrfFile) -> None:
             + "\n"
         )
         srf_file_handle.write(f"POINTS {len(srf.points)}\n")
+        srf.points["point_index"] = np.arange(len(srf.points))
+
         srf.points.apply(
             functools.partial(write_srf_point, srf_file_handle, srf), axis=1
         )
+        srf.points.drop("point_index")

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -144,6 +144,10 @@ class SrfFile:
 
         The final two columns are computed from the SRF and are not saved to
         disk. See the linked documentation on the SRF format for more details.
+
+    References
+    ----------
+    SRF File Format Doc: https://wiki.canterbury.ac.nz/display/QuakeCore/File+Formats+Used+On+GM
     """
 
     version: str

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -367,24 +367,30 @@ def write_srf_point(srf_file: TextIO, srf: SrfFile, point: pd.Series) -> None:
         The point to write.
     """
     index = point.name
-    slipt1 = np.trim_zeros(
-        srf.slipt1_array.data[
-            srf.slipt1_array.indptr[index] : srf.slipt1_array.indptr[index + 1]
-        ]
+    slipt1 = (
+        np.trim_zeros(
+            srf.slipt1_array.data[
+                srf.slipt1_array.indptr[index] : srf.slipt1_array.indptr[index + 1]
+            ]
+        )
         if srf.slipt1_array is not None
         else None
     )
-    slipt2 = np.trim_zeros(
-        srf.slipt2_array.data[
-            srf.slipt2_array.indptr[index] : srf.slipt2_array.indptr[index + 1]
-        ]
+    slipt2 = (
+        np.trim_zeros(
+            srf.slipt2_array.data[
+                srf.slipt2_array.indptr[index] : srf.slipt2_array.indptr[index + 1]
+            ]
+        )
         if srf.slipt2_array is not None
         else None
     )
-    slipt3 = np.trim_zeros(
-        srf.slipt3_array.data[
-            srf.slipt3_array.indptr[index] : srf.slipt3_array.indptr[index + 1]
-        ]
+    slipt3 = (
+        np.trim_zeros(
+            srf.slipt3_array.data[
+                srf.slipt3_array.indptr[index] : srf.slipt3_array.indptr[index + 1]
+            ]
+        )
         if srf.slipt3_array is not None
         else None
     )

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -434,4 +434,4 @@ def write_srf(srf_ffp: Path, srf: SrfFile) -> None:
         srf.points.apply(
             functools.partial(write_srf_point, srf_file_handle, srf), axis=1
         )
-        srf.points.drop("point_index")
+        srf.points = srf.points.drop(columns="point_index")

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -144,9 +144,9 @@ class SrfFile:
         The final two columns are computed from the SRF and are not saved to
         disk. See the linked documentation on the SRF format for more details.
 
-    slipt{i}_matrix : csr_matrix
-        A sparse matrix containing the ith component of slip for each point and at each timestep, where
-        slipt{i}_matrix[i, j] is the slip for the ith patch at time t = j * dt. See also: SRFFile.slip.
+    slipt{i}_array : csr_array
+        A sparse array containing the ith component of slip for each point and at each timestep, where
+        slipt{i}_array[i, j] is the slip for the ith patch at time t = j * dt. See also: SRFFile.slip.
 
     References
     ----------
@@ -156,19 +156,29 @@ class SrfFile:
     version: str
     header: pd.DataFrame
     points: pd.DataFrame
-    slipt1_matrix: sp.sparse.csr_matrix
-    slipt2_matrix: sp.sparse.csr_matrix
-    slipt3_matrix: sp.sparse.csr_matrix
+    slipt1_array: sp.sparse.csr_array
+    slipt2_array: sp.sparse.csr_array
+    slipt3_array: sp.sparse.csr_array
 
     @property
     def slip(self):
-        """csr_matrix: sparse matrix representing slip in all components"""
-        slip_matrix = self.slipt1_matrix.power(2)
-        if self.slipt2_matrix:
-            slip_matrix += self.slipt2_matrix.power(2)
-        if self.slipt3_matrix:
-            slip_matrix += self.slipt3_matrix.power(2)
-        return slip_matrix.sqrt()
+        """csr_array: sparse array representing slip in all components"""
+        slip_array = self.slipt1_array.power(2)
+        if self.slipt2_array:
+            slip_array += self.slipt2_array.power(2)
+        if self.slipt3_array:
+            slip_array += self.slipt3_array.power(2)
+        return slip_array.sqrt()
+
+    @property
+    def nt(self):
+        """int: The number of timeslices in the SRF."""
+        return self.slipt1_array.shape[1]
+
+    @property
+    def dt(self):
+        """float: time resolution of SRF."""
+        return self.points["dt"].iloc[0]
 
     @property
     def segments(self) -> Segments:
@@ -300,14 +310,14 @@ def read_srf(srf_ffp: Path) -> SrfFile:
             )
         point_count = int(points_count_match.group(1))
 
-        points_metadata, slipt1_matrix, slipt2_matrix, slipt3_matrix = (
+        points_metadata, slipt1_array, slipt2_array, slipt3_array = (
             srf_reader.read_srf_points(srf_file_handle, point_count)
         )
         points_df = pd.DataFrame(
             data=points_metadata,
             columns=[
-                "lat",
                 "lon",
+                "lat",
                 "dep",
                 "stk",
                 "dip",
@@ -324,7 +334,7 @@ def read_srf(srf_ffp: Path) -> SrfFile:
             points_df["slip1"] ** 2 + points_df["slip2"] ** 2 + points_df["slip3"] ** 2
         )
         return SrfFile(
-            version, headers, points_df, slipt1_matrix, slipt2_matrix, slipt3_matrix
+            version, headers, points_df, slipt1_array, slipt2_array, slipt3_array
         )
 
 

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -367,21 +367,21 @@ def write_srf_point(srf_file: TextIO, srf: SrfFile, point: pd.Series) -> None:
         The point to write.
     """
     index = point.name
-    slipt1 = (
+    slipt1 = np.trim_zeros(
         srf.slipt1_array.data[
             srf.slipt1_array.indptr[index] : srf.slipt1_array.indptr[index + 1]
         ]
         if srf.slipt1_array is not None
         else None
     )
-    slipt2 = (
+    slipt2 = np.trim_zeros(
         srf.slipt2_array.data[
             srf.slipt2_array.indptr[index] : srf.slipt2_array.indptr[index + 1]
         ]
         if srf.slipt2_array is not None
         else None
     )
-    slipt3 = (
+    slipt3 = np.trim_zeros(
         srf.slipt3_array.data[
             srf.slipt3_array.indptr[index] : srf.slipt3_array.indptr[index + 1]
         ]

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -249,56 +249,6 @@ def read_int(srf_file: TextIO, label: Optional[str] = None) -> int:
             raise SrfParseError(f'Expecting int, got: "{int_str}"')
 
 
-def read_srf_point(srf_file: TextIO) -> dict[str, int | float]:
-    """Read a single SRF point from a file handle.
-
-    Parameters
-    ----------
-    srf_file : TextIO
-        The file handle of the SRF file, pointing to the start of the
-        line.
-
-    Returns
-    -------
-    dict[str, int | float]
-        A dictionary containing the values for the point.
-    """
-    # skip optional first spaces
-    row = {
-        "lon": read_float(srf_file, label="lon"),
-        "lat": read_float(srf_file, label="lat"),
-        "dep": read_float(srf_file, label="dep"),
-        "stk": read_float(srf_file, label="stk"),
-        "dip": read_float(srf_file, label="dip"),
-        "area": read_float(srf_file, label="area"),
-        "tinit": read_float(srf_file, label="tinit"),
-        "dt": read_float(srf_file, label="dt"),
-        "rake": read_float(srf_file, label="rake"),
-        "slip1": read_float(srf_file, label="slip1"),
-    }
-    nt1 = read_int(srf_file, label="nt1")
-    row["slip2"] = read_float(srf_file, label="slip2")
-    nt2 = read_int(srf_file, label="nt2")
-    row["slip3"] = read_float(srf_file, label="slip3")
-    nt3 = read_int(srf_file, label="nt3")
-    row["slipt1"] = np.fromiter(
-        (read_float(srf_file, label="slipt1") for _ in range(nt1)), float
-    )
-    row["slipt2"] = np.fromiter(
-        (read_float(srf_file, label="slipt2") for _ in range(nt2)), float
-    )
-    row["slipt3"] = np.fromiter(
-        (read_float(srf_file, label="slipt2") for _ in range(nt3)), float
-    )
-    length = max(len(row["slipt1"]), len(row["slipt2"]), len(row["slipt3"]))
-    row["slipt"] = np.sqrt(
-        np.pad(row["slipt1"], (0, length - len(row["slipt1"])), mode="constant") ** 2
-        + np.pad(row["slipt2"], (0, length - len(row["slipt2"])), mode="constant") ** 2
-        + np.pad(row["slipt3"], (0, length - len(row["slipt3"])), mode="constant") ** 2
-    )
-    return row
-
-
 def read_srf(srf_ffp: Path) -> SrfFile:
     """Read an SRF file into an SrfFile object.
 

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -368,29 +368,23 @@ def write_srf_point(srf_file: TextIO, srf: SrfFile, point: pd.Series) -> None:
     """
     index = point.name
     slipt1 = (
-        np.trim_zeros(
-            srf.slipt1_array.data[
-                srf.slipt1_array.indptr[index] : srf.slipt1_array.indptr[index + 1]
-            ]
-        )
+        srf.slipt1_array.data[
+            srf.slipt1_array.indptr[index] : srf.slipt1_array.indptr[index + 1]
+        ]
         if srf.slipt1_array is not None
         else None
     )
     slipt2 = (
-        np.trim_zeros(
-            srf.slipt2_array.data[
-                srf.slipt2_array.indptr[index] : srf.slipt2_array.indptr[index + 1]
-            ]
-        )
+        srf.slipt2_array.data[
+            srf.slipt2_array.indptr[index] : srf.slipt2_array.indptr[index + 1]
+        ]
         if srf.slipt2_array is not None
         else None
     )
     slipt3 = (
-        np.trim_zeros(
-            srf.slipt3_array.data[
-                srf.slipt3_array.indptr[index] : srf.slipt3_array.indptr[index + 1]
-            ]
-        )
+        srf.slipt3_array.data[
+            srf.slipt3_array.indptr[index] : srf.slipt3_array.indptr[index + 1]
+        ]
         if srf.slipt3_array is not None
         else None
     )

--- a/source_modelling/srf_reader.pyx
+++ b/source_modelling/srf_reader.pyx
@@ -29,17 +29,17 @@ cdef struct sparse_matrix:
     # Attributes
     # -----------
     # rows : int
-    # Counts the number of rows in the sparse matrix.
+    #     Counts the number of rows in the sparse matrix.
     # row_counter : int
-    # Records the current row.
+    #     Records the current row.
     # row_ptr : int*
-    # Row index value array.
+    #     Row index value array.
     # entries : int
-    # Counts the total number of entries in the array.
+    #     Counts the total number of entries in the array.
     # col_ptr : int*
-    # Column index value array.
+    #     Column index value array.
     # data : double*
-    # Entry value array.
+    #     Entry value array.
     # 
     # References
     # ----------

--- a/source_modelling/srf_reader.pyx
+++ b/source_modelling/srf_reader.pyx
@@ -1,8 +1,10 @@
 cimport numpy as np
-import numpy as pnp
-import scipy as sp
 from libc.stdio cimport *
 from libc.stdlib cimport *
+
+import numpy as pnp
+import scipy as sp
+
 np.import_array()
 
 cdef struct sparse_matrix:

--- a/source_modelling/srf_reader.pyx
+++ b/source_modelling/srf_reader.pyx
@@ -1,0 +1,136 @@
+cimport numpy as np
+import numpy as pnp
+import scipy as sp
+from libc.stdio cimport *
+from libc.stdlib cimport *
+np.import_array()
+
+cdef struct sparse_matrix:
+     int rows
+     int row_counter
+     int* row_ptr
+     int entries
+     int* col_ptr
+     double* data
+
+
+     
+ctypedef np.double_t DTYPE_t
+ctypedef np.int_t ITYPE_t
+DTYPE = pnp.double
+
+
+cdef void malloc_sparse_matrix(sparse_matrix* slip_matrix, int num_rows):
+    slip_matrix.rows = num_rows
+    slip_matrix.row_counter = 0
+    slip_matrix.row_ptr = <int *>malloc(num_rows * sizeof(int))
+    slip_matrix.entries = 0
+    slip_matrix.col_ptr = NULL
+    slip_matrix.data = NULL
+
+cdef void free_sparse_matrix(sparse_matrix slip_matrix):
+    free(slip_matrix.row_ptr);
+    free(slip_matrix.col_ptr);
+    free(slip_matrix.data);
+
+cdef void read_slipt_values(FILE* srf_file, int start_column, int slip_count, sparse_matrix* slip_matrix):
+    cdef int slip_index
+    cdef void* intermediate
+    slip_matrix.row_ptr[slip_matrix.row_counter] = slip_matrix.entries
+    slip_matrix.row_counter += 1
+    if slip_count > 0:
+        # printf("%d\n", slip_count);
+        slip_matrix.entries += slip_count
+        # printf("Entries: %d\n", slip_matrix.entries)
+        if slip_matrix.col_ptr == NULL:
+            slip_matrix.col_ptr = <int*> malloc(slip_matrix.entries * sizeof(int));
+        else:
+            # printf("Column PTR: %p\n", slip_matrix.col_ptr);
+            # printf("Can Deref? %d\n", slip_matrix.col_ptr[0]);
+            # printf("New Size: %d\n", slip_matrix.entries * sizeof(int))
+            slip_matrix.col_ptr = <int*>realloc(slip_matrix.col_ptr, slip_matrix.entries  * sizeof(int));
+        if slip_matrix.data == NULL:
+            slip_matrix.data = <double*>malloc(slip_matrix.entries * sizeof(double));
+        else:
+            # printf("Column PTR: %p\n", slip_matrix.data);
+            # printf("New Size: %d\n", slip_matrix.entries * sizeof(int))
+            slip_matrix.data = <double*>realloc(slip_matrix.data , slip_matrix.entries * sizeof(double));
+        for slip_index in range(slip_matrix.entries - slip_count, slip_matrix.entries):
+            # printf("Storing %d at %d\n", start_column + slip_index - slip_matrix.entries + slip_count, slip_index)
+            slip_matrix.col_ptr[slip_index] = start_column + slip_index - slip_matrix.entries + slip_count
+            fscanf(srf_file, "%lf", &slip_matrix.data[slip_index])
+        
+
+
+cdef void read_srf_points_loop(FILE* srf_file, int point_count, DTYPE_t[:, :] metadata, sparse_matrix* slipt1s, sparse_matrix* slipt2s, sparse_matrix* slipt3s):
+    cdef int nt1
+    cdef int nt2
+    cdef int nt3
+    cdef int i
+    cdef int start_column_index
+    for i in range(point_count):
+        fscanf(srf_file, "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %d %lf %d %lf %d",
+               &metadata[i, 0], # lat
+               &metadata[i, 1], # lon
+               &metadata[i, 2], # dep
+               &metadata[i, 3], # stk
+               &metadata[i, 4], # dip
+               &metadata[i, 5], # area
+               &metadata[i, 6], # tinit
+               &metadata[i, 7], # dt
+               &metadata[i, 8], # rake
+               &metadata[i, 9], # slip1
+               &nt1,
+               &metadata[i, 10], # slip2
+               &nt2,
+               &metadata[i, 11], # slip3
+               &nt3
+               )
+        start_column_index = <int> (metadata[i, 6] / metadata[i, 7])
+        read_slipt_values(srf_file, start_column_index, nt1, slipt1s)
+        read_slipt_values(srf_file, start_column_index, nt2, slipt2s)
+        read_slipt_values(srf_file, start_column_index, nt3, slipt3s)
+
+cdef sparse_matrix_to_csr(sparse_matrix matrix):
+    if matrix.entries == 0:
+        return None
+    cdef np.ndarray[DTYPE_t, ndim=1] data = pnp.zeros(matrix.entries, dtype=DTYPE)
+    cdef np.ndarray[ITYPE_t, ndim=1] col_indices = pnp.zeros(matrix.entries, dtype=pnp.int64)
+    cdef np.ndarray[ITYPE_t, ndim=1] row_indices = pnp.zeros(matrix.rows, dtype=pnp.int64)
+    cdef int i = 0
+    
+    for i in range(matrix.entries):
+        data[i] = matrix.data[i]
+        col_indices[i] = matrix.col_ptr[i]
+    i = 0
+    for i in range(matrix.rows):
+        row_indices[i] = matrix.row_ptr[i]
+    
+    return sp.sparse.csr_matrix((data, col_indices, row_indices))
+        
+    
+        
+        
+def read_srf_points(srf_file_handle_py, point_count):
+    cdef np.ndarray[DTYPE_t, ndim=2] metadata = pnp.zeros([point_count, 12], dtype=DTYPE)
+    cdef DTYPE_t[:, :] metadata_view = metadata
+    
+    cdef sparse_matrix slip1ts
+    cdef sparse_matrix slip2ts
+    cdef sparse_matrix slip3ts
+    malloc_sparse_matrix(&slip1ts, point_count)
+    malloc_sparse_matrix(&slip2ts, point_count)
+    malloc_sparse_matrix(&slip3ts, point_count)
+    
+    cdef FILE* cfile = fdopen(srf_file_handle_py.fileno(), 'rb')
+    fseek(cfile, srf_file_handle_py.tell(), SEEK_SET)
+    read_srf_points_loop(cfile, point_count, metadata_view, &slip1ts, &slip2ts, &slip3ts)
+    slip1ts_mat = sparse_matrix_to_csr(slip1ts)
+    slip2ts_mat = sparse_matrix_to_csr(slip2ts)
+    slip3ts_mat = sparse_matrix_to_csr(slip3ts)
+    
+    free_sparse_matrix(slip1ts)
+    free_sparse_matrix(slip2ts)
+    free_sparse_matrix(slip3ts)
+    
+    return metadata, slip1ts_mat, slip2ts_mat, slip3ts_mat

--- a/source_modelling/srf_reader.pyx
+++ b/source_modelling/srf_reader.pyx
@@ -18,7 +18,7 @@ cdef struct sparse_matrix:
 
      
 ctypedef np.double_t DTYPE_t
-ctypedef np.int_t ITYPE_t
+ctypedef np.int64_t ITYPE_t
 DTYPE = pnp.double
 
 
@@ -61,9 +61,7 @@ cdef void read_slipt_values(FILE* srf_file, int start_column, int slip_count, sp
             # printf("Storing %d at %d\n", start_column + slip_index - slip_matrix.entries + slip_count, slip_index)
             slip_matrix.col_ptr[slip_index] = start_column + slip_index - slip_matrix.entries + slip_count
             fscanf(srf_file, "%lf", &slip_matrix.data[slip_index])
-        
-
-
+    
 cdef void read_srf_points_loop(FILE* srf_file, int point_count, DTYPE_t[:, :] metadata, sparse_matrix* slipt1s, sparse_matrix* slipt2s, sparse_matrix* slipt3s):
     cdef int nt1
     cdef int nt2
@@ -98,17 +96,19 @@ cdef sparse_matrix_to_csr(sparse_matrix matrix):
         return None
     cdef np.ndarray[DTYPE_t, ndim=1] data = pnp.zeros(matrix.entries, dtype=DTYPE)
     cdef np.ndarray[ITYPE_t, ndim=1] col_indices = pnp.zeros(matrix.entries, dtype=pnp.int64)
-    cdef np.ndarray[ITYPE_t, ndim=1] row_indices = pnp.zeros(matrix.rows, dtype=pnp.int64)
+    cdef np.ndarray[ITYPE_t, ndim=1] row_indices = pnp.zeros(matrix.rows + 1, dtype=pnp.int64)
     cdef int i = 0
-    
+    cdef int max_col_ind = 0  
     for i in range(matrix.entries):
         data[i] = matrix.data[i]
         col_indices[i] = matrix.col_ptr[i]
+        if max_col_ind <  matrix.col_ptr[i]:
+            max_col_ind = matrix.col_ptr[i]
     i = 0
     for i in range(matrix.rows):
         row_indices[i] = matrix.row_ptr[i]
-    
-    return sp.sparse.csr_matrix((data, col_indices, row_indices))
+    row_indices[matrix.rows] = matrix.entries
+    return sp.sparse.csr_array((data, col_indices, row_indices))
         
     
         

--- a/source_modelling/srf_reader.pyx
+++ b/source_modelling/srf_reader.pyx
@@ -208,7 +208,7 @@ cdef sparse_matrix_to_csr(sparse_matrix matrix):
 
     i = 0
     for i in range(matrix.rows):
-        # Aso Python assignment.
+        # Also Python assignment.
         row_indices[i] = matrix.row_ptr[i]
     row_indices[matrix.rows] = matrix.entries
     return sp.sparse.csr_array((data, col_indices, row_indices))
@@ -232,13 +232,13 @@ def read_srf_points(
     metadata : array
         The metadata for each point.
     slip1ts : sparse matrix
-        The sparse matrix of slip values in the first compenent for each
+        The sparse matrix of slip values in the first component for each
         point.
     slip2ts : sparse matrix
-        The sparse matrix of slip values in the second compenent for each
+        The sparse matrix of slip values in the second component for each
         point.
     slip3ts : sparse matrix
-        The sparse matrix of slip values in the third compenent for each
+        The sparse matrix of slip values in the third component for each
         point.
     """
     cdef np.ndarray[DTYPE_t, ndim=2] metadata = pnp.zeros([point_count, 12], dtype=DTYPE)

--- a/source_modelling/srf_reader.pyx
+++ b/source_modelling/srf_reader.pyx
@@ -2,67 +2,146 @@ cimport numpy as np
 from libc.stdio cimport *
 from libc.stdlib cimport *
 
+from typing import TextIO
+
 import numpy as pnp
+import numpy.typing as npt
 import scipy as sp
+from scipy.sparse import csr_array
 
 np.import_array()
 
-cdef struct sparse_matrix:
-     int rows
-     int row_counter
-     int* row_ptr
-     int entries
-     int* col_ptr
-     double* data
-
-
-     
+# These types are used in place of double, float, etc because they exactly
+# correspond to what numpy uses on whatever system this code runs on.
 ctypedef np.double_t DTYPE_t
 ctypedef np.int64_t ITYPE_t
 DTYPE = pnp.double
 
+# NOTE: sparse matrix structs do not support Python docstrings.
+cdef struct sparse_matrix:
+    # An intermediate CSR matrix representation used for reading slip values.
+    # 
+    # The CSR matrix representation is a highly compressed sparse matrix format
+    # optimised for row operations and matrix multiplication. See the wikipedia
+    # description of the CSR matrix format[0] for a description of how the col_ptr
+    # and row_ptr arrays record the indices of the data.
+    # 
+    # Attributes
+    # -----------
+    # rows : int
+    # Counts the number of rows in the sparse matrix.
+    # row_counter : int
+    # Records the current row.
+    # row_ptr : int*
+    # Row index value array.
+    # entries : int
+    # Counts the total number of entries in the array.
+    # col_ptr : int*
+    # Column index value array.
+    # data : double*
+    # Entry value array.
+    # 
+    # References
+    # ----------
+    # [0]: https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)
+    
+    int rows
+    int row_counter
+    ITYPE_t* row_ptr
+    int entries
+    ITYPE_t* col_ptr
+    DTYPE_t* data
+     
 
 cdef void malloc_sparse_matrix(sparse_matrix* slip_matrix, int num_rows):
+    """ Initialise an empty sparse matrix. 
+
+    Parameters
+    ----------
+    slip_matrix : sparse_matrix*
+        The slip matrix to initialise.
+    num_rows : int
+        The total number of rows for the slip matrix.
+    """
     slip_matrix.rows = num_rows
     slip_matrix.row_counter = 0
-    slip_matrix.row_ptr = <int *>malloc(num_rows * sizeof(int))
+    slip_matrix.row_ptr = <ITYPE_t *>malloc(num_rows * sizeof(ITYPE_t))
     slip_matrix.entries = 0
     slip_matrix.col_ptr = NULL
     slip_matrix.data = NULL
 
 cdef void free_sparse_matrix(sparse_matrix slip_matrix):
+    """ Free a sparse matrix. 
+    
+    Parameters
+    ----------
+    slip_matrix : sparse_matrix
+        The sparse matrix to free.
+    """
     free(slip_matrix.row_ptr);
     free(slip_matrix.col_ptr);
     free(slip_matrix.data);
 
 cdef void read_slipt_values(FILE* srf_file, int start_column, int slip_count, sparse_matrix* slip_matrix):
+    """ Read slip values from srf_file into the sparse matrix as a new row. 
+
+    Parameters
+    ----------
+    srf_file : FILE*
+        File handle for the srf file.
+    start_column : int
+        Store the slip values starting at this column.
+    slip_count : int
+        The number of slip values to read.
+    slip_matrix : sparse_matrix*
+        The matrix to read slip values into.
+    """
     cdef int slip_index
-    cdef void* intermediate
+    # The value of row_ptr[i] records the index of the first value of i-th
+    # row in the data array. Because we are starting a new row, we thus
+    # record it's starting position at the end of the current data array.
     slip_matrix.row_ptr[slip_matrix.row_counter] = slip_matrix.entries
     slip_matrix.row_counter += 1
+
     if slip_count > 0:
-        # printf("%d\n", slip_count);
         slip_matrix.entries += slip_count
-        # printf("Entries: %d\n", slip_matrix.entries)
+        # Either allocate or grow the slip matrix row, column and data arrays
+        # to fit the new slip values.
         if slip_matrix.col_ptr == NULL:
-            slip_matrix.col_ptr = <int*> malloc(slip_matrix.entries * sizeof(int));
+            slip_matrix.col_ptr = <ITYPE_t*> malloc(slip_matrix.entries * sizeof(ITYPE_t));
         else:
-            # printf("Column PTR: %p\n", slip_matrix.col_ptr);
-            # printf("Can Deref? %d\n", slip_matrix.col_ptr[0]);
-            # printf("New Size: %d\n", slip_matrix.entries * sizeof(int))
-            slip_matrix.col_ptr = <int*>realloc(slip_matrix.col_ptr, slip_matrix.entries  * sizeof(int));
+            slip_matrix.col_ptr = <ITYPE_t*>realloc(slip_matrix.col_ptr, slip_matrix.entries  * sizeof(ITYPE_t));
+
         if slip_matrix.data == NULL:
-            slip_matrix.data = <double*>malloc(slip_matrix.entries * sizeof(double));
+            slip_matrix.data = <DTYPE_t*>malloc(slip_matrix.entries * sizeof(DTYPE_t));
         else:
-            # printf("Column PTR: %p\n", slip_matrix.data);
-            # printf("New Size: %d\n", slip_matrix.entries * sizeof(int))
-            slip_matrix.data = <double*>realloc(slip_matrix.data , slip_matrix.entries * sizeof(double));
+            slip_matrix.data = <DTYPE_t*>realloc(slip_matrix.data , slip_matrix.entries * sizeof(DTYPE_t));
+
         for slip_index in range(slip_matrix.entries - slip_count, slip_matrix.entries):
-            # printf("Storing %d at %d\n", start_column + slip_index - slip_matrix.entries + slip_count, slip_index)
+            # The column ptr records the column for each entry in the data array.
+            #           column index        = start column + current offset from start of this row's slip values
+            #                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             slip_matrix.col_ptr[slip_index] = start_column + slip_index - slip_matrix.entries + slip_count
             fscanf(srf_file, "%lf", &slip_matrix.data[slip_index])
     
 cdef void read_srf_points_loop(FILE* srf_file, int point_count, DTYPE_t[:, :] metadata, sparse_matrix* slipt1s, sparse_matrix* slipt2s, sparse_matrix* slipt3s):
+    """ Loop over the number of points and read in the SRF data from srf_file. 
+
+    Parameters
+    ----------
+    srf_file : FILE*
+        SRF file to read from.
+    point_count : int
+        Number of points to read.
+    metadata : DTYPE_t[:, :]
+        Metadata about each point (lat, lon, dt, etc).
+    slipt{i}s : sparse_matrix*
+        The slip for each point in the i-th component. The matrix is established such that
+
+        slipt{i}s[j, k] = the slip value for point j in component i at time k*dt
+
+        Thus, we assume that dt is constant for each point.
+    """
     cdef int nt1
     cdef int nt2
     cdef int nt3
@@ -70,50 +149,98 @@ cdef void read_srf_points_loop(FILE* srf_file, int point_count, DTYPE_t[:, :] me
     cdef int start_column_index
     for i in range(point_count):
         fscanf(srf_file, "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %d %lf %d %lf %d",
-               &metadata[i, 0], # lat
-               &metadata[i, 1], # lon
-               &metadata[i, 2], # dep
-               &metadata[i, 3], # stk
-               &metadata[i, 4], # dip
-               &metadata[i, 5], # area
-               &metadata[i, 6], # tinit
-               &metadata[i, 7], # dt
-               &metadata[i, 8], # rake
-               &metadata[i, 9], # slip1
-               &nt1,
+               &metadata[i, 0],  # lat
+               &metadata[i, 1],  # lon
+               &metadata[i, 2],  # dep
+               &metadata[i, 3],  # stk
+               &metadata[i, 4],  # dip
+               &metadata[i, 5],  # area
+               &metadata[i, 6],  # tinit
+               &metadata[i, 7],  # dt
+               &metadata[i, 8],  # rake
+               &metadata[i, 9],  # slip1
+               &nt1,             # number of slipt1 values for this point
                &metadata[i, 10], # slip2
-               &nt2,
+               &nt2,             # number of slipt2 values for this point
                &metadata[i, 11], # slip3
-               &nt3
+               &nt3              # number of slipt3 values for this point
                )
         start_column_index = <int> (metadata[i, 6] / metadata[i, 7])
         read_slipt_values(srf_file, start_column_index, nt1, slipt1s)
         read_slipt_values(srf_file, start_column_index, nt2, slipt2s)
         read_slipt_values(srf_file, start_column_index, nt3, slipt3s)
 
+# NOTE: not sure what the return type should be here because it a C function
+# returning a Python value. So I have just left it blank.
 cdef sparse_matrix_to_csr(sparse_matrix matrix):
+    """ Convert the internal sparse matrix representation into a scipy sparse csr array. 
+
+    Parameters
+    ----------
+    matrix : sparse_matrix
+        The matrix to convert.
+
+    Returns
+    -------
+    csr_array
+        The scipy csr_array representation of matrix, or None if the matrix is empty.
+    """
     if matrix.entries == 0:
         return None
+
+    
+    # Basically, we just have to copy the data from the arrays into numpy arrays.
+    # We do this in a loop to ensure that the values are owned by numpy
+    # (and hence free'd by python instead of leaking).
     cdef np.ndarray[DTYPE_t, ndim=1] data = pnp.zeros(matrix.entries, dtype=DTYPE)
     cdef np.ndarray[ITYPE_t, ndim=1] col_indices = pnp.zeros(matrix.entries, dtype=pnp.int64)
     cdef np.ndarray[ITYPE_t, ndim=1] row_indices = pnp.zeros(matrix.rows + 1, dtype=pnp.int64)
     cdef int i = 0
     cdef int max_col_ind = 0  
+
     for i in range(matrix.entries):
+        # These "=" assignments are done in Python, not C!
         data[i] = matrix.data[i]
         col_indices[i] = matrix.col_ptr[i]
         if max_col_ind <  matrix.col_ptr[i]:
+            # This is a regular C assignment
             max_col_ind = matrix.col_ptr[i]
+
     i = 0
     for i in range(matrix.rows):
+        # Aso Python assignment.
         row_indices[i] = matrix.row_ptr[i]
     row_indices[matrix.rows] = matrix.entries
     return sp.sparse.csr_array((data, col_indices, row_indices))
         
-    
         
-        
-def read_srf_points(srf_file_handle_py, point_count):
+def read_srf_points(
+        srf_file_handle_py: TextIO, 
+        point_count: int
+    ) -> tuple[npt.NDArray[DTYPE], csr_array, csr_array, csr_array]:
+    """ Read point_count SRF points from an SRF file.
+
+    Parameters
+    ----------
+    srf_file_handle_py : TextIO
+        The SRF file to read from.
+    point_count : int
+        The number of points to read.
+
+    Returns
+    -------
+    metadata : array
+        The metadata for each point.
+    slip1ts : sparse matrix
+        The sparse matrix of slip values in the first compenent for each
+        point.
+    slip2ts : sparse matrix
+        The sparse matrix of slip values in the second compenent for each
+        point.
+    slip3ts : sparse matrix
+        The sparse matrix of slip values in the third compenent for each
+        point.
+    """
     cdef np.ndarray[DTYPE_t, ndim=2] metadata = pnp.zeros([point_count, 12], dtype=DTYPE)
     cdef DTYPE_t[:, :] metadata_view = metadata
     
@@ -123,9 +250,12 @@ def read_srf_points(srf_file_handle_py, point_count):
     malloc_sparse_matrix(&slip1ts, point_count)
     malloc_sparse_matrix(&slip2ts, point_count)
     malloc_sparse_matrix(&slip3ts, point_count)
-    
+
+    # This code obtains a C file handle pointing to the same location as
+    # the Python file handle.
     cdef FILE* cfile = fdopen(srf_file_handle_py.fileno(), 'rb')
     fseek(cfile, srf_file_handle_py.tell(), SEEK_SET)
+
     read_srf_points_loop(cfile, point_count, metadata_view, &slip1ts, &slip2ts, &slip3ts)
     slip1ts_mat = sparse_matrix_to_csr(slip1ts)
     slip2ts_mat = sparse_matrix_to_csr(slip2ts)


### PR DESCRIPTION
This PR adds a few SRF module enhancements:

1. A segment view that lets you iterate over fault segments in an SRF efficiently,
2. A `slipt` property that is the total slip at each timestep for each patch. The SRF spec stores slip in three components `slipt1`, `slipt2`, `slipt3`, but most often we care about the total slip in all three directions. 
3. A `slip` property that is the total slip for each patch. The `slip` parameter is related to `slipt` as the integral of `slipt` over time.
4. Documentation in the class docstring of each column in the points and header dataframe.

These changes are used for the plots I'm generating, and also by Cesar, who is also using the srf module for his work.