### PR TITLE
Plane construction and extraction.

### DIFF
--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -357,18 +357,24 @@ class Plane:
         ----------
         centroid : np.ndarray
             The centre of the fault plane in lat, lon, and optionally depth (km) coordinates.
-        strike : float
-            The strike of the fault (in degrees).
-        dip_dir : Optional[float]
-            The dip direction of the fault (in degrees). If None this is assumed to be strike + 90 degrees.
-        top : float
-            The top depth of the plane (in km).
-        bottom : float
-            The bottom depth of the plane (in km).
+        dip : float
+            The dip of the fault (in degrees).
         length : float
             The length of the fault plane (in km).
-        projected_width : float
-            The projected width of the fault plane (in km).
+        width : float
+            The width of the fault plane (in km).
+        dtop : Optional[float]
+            The top depth of the plane (in km).
+        dbottom : Optional[float]
+            The bottom depth of the plane (in km).
+        strike : Optional[float]
+            The strike of the fault (in degrees).
+        dip_dir : Optional[float]
+            The dip direction of the fault (in degrees). If None, this is assumed to be strike + 90 degrees.
+        strike_nztm : Optional[float]
+            The NZTM strike of the fault (in degrees).
+        dip_dir_nztm : Optional[float]
+            The NZTM dip direction of the fault (in degrees).
 
         Returns
         -------
@@ -379,9 +385,18 @@ class Plane:
 
         Note
         ----
-        The angles `strike` and `dip_dir` are NZTM bearings from
-        north. If you are using WGS84 bearings you need to convert
-        them to NZTM bearings before you call this function.
+        You must supply at least one of `dtop`, `dbottom` or centroid
+        depth (i.e. adding a third component to `centroid` for the
+        depth). If you provide more than one, they must be consistent
+        with each other with respect to dip. These conditions are
+        checked by the method.
+
+        Valid combinations of `strike` and `strike_nztm`:
+        - Must supply exactly one of `strike` or `strike_nztm`.
+
+        Valid combinations of `dip_dir` and `dip_dir_nztm`:
+        - Must supply at most one of `dip_dir` or `dip_dir_nztm`.
+        - If neither is supplied, `dip_dir` is assumed to be `strike + 90`.
         """
         # Check that dtop, dbottom and centroid depth are consistent
         if (

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -368,9 +368,9 @@ class Plane:
         dbottom : Optional[float]
             The bottom depth of the plane (in km).
         strike : Optional[float]
-            The strike of the fault (in degrees).
+            The WGS84 strike bearing of the fault (in degrees).
         dip_dir : Optional[float]
-            The dip direction of the fault (in degrees). If None, this is assumed to be strike + 90 degrees.
+            The WGS84 dip direction bearing of the fault (in degrees). If None, this is assumed to be strike + 90 degrees.
         strike_nztm : Optional[float]
             The NZTM strike of the fault (in degrees).
         dip_dir_nztm : Optional[float]

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -57,8 +57,9 @@ import pandas as pd
 import scipy as sp
 import shapely
 
-from qcore import coordinates
+from qcore import coordinates, geo
 from source_modelling import srf_reader
+from source_modelling.sources import Plane
 
 PLANE_COUNT_RE = r"PLANE (\d+)"
 POINT_COUNT_RE = r"POINTS (\d+)"
@@ -214,6 +215,46 @@ class SrfFile:
     def segments(self) -> Segments:
         """Segments: A sequence of segments in the SRF."""
         return Segments(self.header, self.points)
+
+    @property
+    def planes(self) -> list[Plane]:
+        """list[Plane]: The list of planes in the SRF."""
+        planes = []
+        for (_, segment_header), segment in zip(self.header.iterrows(), self.segments):
+            length = segment_header["len"]
+            width = segment_header["wid"]
+            nstk = int(segment_header["nstk"])
+            centroid = np.array([segment_header["elat"], segment_header["elon"]])
+            dip = segment_header["dip"]
+            dtop = segment_header["dtop"]
+
+            dip_direction = coordinates.wgs_depth_to_nztm(
+                segment[["lat", "lon"]].iloc[nstk]
+            ) - coordinates.wgs_depth_to_nztm(segment[["lat", "lon"]].iloc[0])
+            dip_direction_bearing = None
+            if not np.allclose(dip_direction, 0):
+                dip_direction_bearing = geo.oriented_bearing_wrt_normal(
+                    np.array([1.0, 0.0, 0.0]),
+                    np.append(dip_direction, 0),
+                    np.array([0.0, 0.0, 1.0]),
+                )
+
+            strike = coordinates.great_circle_bearing_to_nztm_bearing(
+                centroid, length / 2, segment_header["stk"]
+            )
+
+            planes.append(
+                Plane.from_centroid_strike_dip(
+                    centroid,
+                    strike,
+                    dip,
+                    dip_direction_bearing,
+                    length,
+                    width,
+                    dtop=dtop,
+                )
+            )
+        return planes
 
 
 class SrfParseError(Exception):

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -239,19 +239,17 @@ class SrfFile:
                     np.array([0.0, 0.0, 1.0]),
                 )
 
-            strike = coordinates.great_circle_bearing_to_nztm_bearing(
-                centroid, length / 2, segment_header["stk"]
-            )
+            strike = segment_header["stk"]
 
             planes.append(
                 Plane.from_centroid_strike_dip(
                     centroid,
-                    strike,
                     dip,
-                    dip_direction_bearing,
                     length,
                     width,
                     dtop=dtop,
+                    strike=strike,
+                    dip_dir_nztm=dip_direction_bearing,
                 )
             )
         return planes

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import numpy as np
+import pytest
 import scipy as sp
 import shapely
 from hypothesis import assume, given, seed, settings
@@ -203,66 +204,178 @@ def test_point_rjb(
 
 @given(
     length=st.floats(0.1, 1000),
-    projected_width=st.floats(0.1, 1000),
+    width=st.floats(0.1, 1000),
     strike=st.floats(0, 179),
     dip_dir=st.floats(0, 179),
-    top=st.floats(0, 100),
-    depth=st.floats(0.1, 100),
-    centroid=st.builds(coordinate, lat=st.floats(-50, -31), lon=st.floats(160, 180)),
+    dip=st.floats(0.1, 90),
+    centroid=st.builds(
+        coordinate,
+        lat=st.floats(-50, -31),
+        lon=st.floats(160, 180),
+        depth=st.floats(1, 10),
+    ),
 )
 def test_plane_construction(
     length: float,
-    projected_width: float,
+    width: float,
     strike: float,
+    dip: float,
     dip_dir: float,
-    top: float,
-    depth: float,
     centroid: np.ndarray,
 ):
     assume(valid_coordinates(centroid))
     plane = Plane.from_centroid_strike_dip(
-        centroid, strike, dip_dir, top, top + depth, length, projected_width
+        centroid,
+        strike,
+        dip,
+        dip_dir,
+        length,
+        width,
     )
     assert np.isclose(plane.length, length, atol=1e-6)
+    assert np.isclose(plane.width, width, atol=1e-6)
     assert np.isclose(
-        plane.width, plane.projected_width / np.cos(np.radians(plane.dip)), atol=1e-6
+        plane.projected_width, plane.width * np.cos(np.radians(plane.dip)), atol=1e-6
     )
     assert np.allclose(
         shapely.get_coordinates(plane.geometry, include_z=True)[:-1], plane.bounds
     )
-    assert np.isclose(plane.projected_width, projected_width, atol=1e-6)
-    assert np.isclose(plane.strike, strike, atol=1e-6)
-    assert np.isclose(plane.dip_dir, dip_dir, atol=1e-6)
-    assert np.allclose(plane.centroid[:2], centroid, atol=1e-6)
+    assert np.isclose(plane.strike_nztm, strike, atol=1e-6)
+    if plane.dip != 90:
+        assert np.isclose(plane.dip_dir_nztm, dip_dir, atol=1e-6)
+    assert np.allclose(plane.centroid, centroid * np.array([1, 1, 1000]), atol=1e-6)
 
 
-def fault_plane(
-    length: float,
-    projected_width: float,
-    strike: float,
-    dip_dir: float,
-    top: float,
-    depth: float,
-    centroid: np.ndarray,
-) -> Plane:
-    return Plane.from_centroid_strike_dip(
-        centroid, strike, dip_dir, top, top + depth, length, projected_width
+@pytest.mark.parametrize(
+    "centroid, strike, dip, dip_dir, length, width, dtop, dbottom, exception_message",
+    [
+        # Case where top and bottom depths are not consistent with dip and width
+        (
+            np.array([0, 0, 0]),
+            45,
+            30,
+            None,
+            10,
+            5,
+            1,
+            2,
+            r"Top and bottom depths are not consistent with dip and width parameters\.",
+        ),
+        # Case where top and bottom depths are not consistent with centroid depth
+        (
+            np.array([0, 0, 5]),
+            45,
+            30,
+            None,
+            10,
+            5,
+            1,
+            10,
+            r"Top and bottom depths are not consistent with centroid depth\.",
+        ),
+        # Case where neither top, bottom, nor centroid depth is given
+        (
+            np.array([0, 0]),
+            45,
+            30,
+            None,
+            10,
+            5,
+            None,
+            None,
+            r"At least one of top, bottom, or centroid depth must be given\.",
+        ),
+        # Case where centroid depth and dtop are inconsistent
+        (
+            np.array([0, 0, 5]),
+            45,
+            30,
+            None,
+            10,
+            5,
+            1,
+            None,
+            r"Centroid depth and dtop are inconsistent\.",
+        ),
+        # Case where centroid depth and dbottom are inconsistent
+        (
+            np.array([0, 0, 5]),
+            45,
+            30,
+            None,
+            10,
+            5,
+            None,
+            9,
+            r"Centroid depth and dbottom are inconsistent\.",
+        ),
+    ],
+)
+def test_from_centroid_strike_dip_failure_cases(
+    centroid,
+    strike,
+    dip,
+    dip_dir,
+    length,
+    width,
+    dtop,
+    dbottom,
+    exception_message,
+):
+    with pytest.raises(ValueError):
+        Plane.from_centroid_strike_dip(
+            centroid, strike, dip, dip_dir, length, width, dtop, dbottom
+        )
+
+
+@pytest.mark.parametrize(
+    "centroid, strike, dip, dip_dir, length, width, dtop, dbottom, expected_dtop, expected_dbottom",
+    [
+        # Case where both dtop and dbottom are None
+        (np.array([0, 0, 5]), 45, 30, None, 10, 5, None, None, 5 - 5 / 4, 5 + 5 / 4),
+        # Case where dtop is None and dbottom is provided
+        (np.array([0, 0]), 45, 30, None, 10, 5, None, 10, 10 - 5 / 2, 10),
+        # Case where dbottom is None and dtop is provided
+        (np.array([0, 0]), 45, 30, None, 10, 5, 0, None, 0, 5 / 2),
+    ],
+)
+def test_from_centroid_strike_dip_dtop_dbottom_derivation(
+    centroid,
+    strike,
+    dip,
+    dip_dir,
+    length,
+    width,
+    dtop,
+    dbottom,
+    expected_dtop,
+    expected_dbottom,
+):
+    plane = Plane.from_centroid_strike_dip(
+        centroid, strike, dip, dip_dir, length, width, dtop, dbottom
     )
+    assert np.isclose(plane.corners[0, -1], expected_dtop * 1000)
+    assert np.isclose(plane.corners[-1, -1], expected_dbottom * 1000)
+
+
+fault_plane = st.builds(
+    Plane.from_centroid_strike_dip,
+    centroid=st.builds(
+        coordinate,
+        lat=st.floats(-50, -31),
+        lon=st.floats(160, 180),
+        depth=st.floats(1, 10),
+    ),
+    length=st.floats(0.1, 1000),
+    width=st.floats(0.1, 1000),
+    strike=st.floats(0, 179),
+    dip_dir=st.floats(5, 179),
+    dip=st.floats(0.1, 90),
+)
 
 
 @given(
-    plane=st.builds(
-        fault_plane,
-        length=st.floats(0.1, 1000),
-        projected_width=st.floats(0.1, 1000),
-        strike=st.floats(0, 179),
-        dip_dir=st.floats(5, 179),
-        top=st.floats(0, 100),
-        depth=st.floats(0.1, 100),
-        centroid=st.builds(
-            coordinate, lat=st.floats(-50, -31), lon=st.floats(160, 180)
-        ),
-    ),
+    plane=fault_plane,
     point=st.builds(
         coordinate,
         lat=st.floats(-50, -31),
@@ -296,18 +409,7 @@ def test_plane_rrup(plane: Plane, point: np.ndarray):
 
 
 @given(
-    plane=st.builds(
-        fault_plane,
-        length=st.floats(0.1, 1000),
-        projected_width=st.floats(0.1, 1000),
-        strike=st.floats(0, 179),
-        dip_dir=st.floats(5, 179),
-        top=st.floats(0, 100),
-        depth=st.floats(0.1, 100),
-        centroid=st.builds(
-            coordinate, lat=st.floats(-50, -31), lon=st.floats(160, 180)
-        ),
-    ),
+    plane=fault_plane,
     local_coordinates=nst.arrays(
         float, (2,), elements={"min_value": 0, "max_value": 1}
     ),
@@ -323,23 +425,13 @@ def test_plane_rrup_in_plane(plane: Plane, local_coordinates: np.ndarray):
 
 
 @given(
-    plane=st.builds(
-        fault_plane,
-        length=st.floats(0.1, 1000),
-        projected_width=st.floats(0.1, 1000),
-        strike=st.floats(0, 179),
-        dip_dir=st.floats(1, 179),
-        top=st.floats(0, 100),
-        depth=st.floats(0.1, 100),
-        centroid=st.builds(
-            coordinate, lat=st.floats(-50, -31), lon=st.floats(160, 180)
-        ),
-    ),
+    plane=fault_plane,
     distance=st.floats(1, 1000),
 )
 def test_plane_rjb(plane: Plane, distance: float):
     # if dip dir is too close to strike it will create a degenerate geometry that rjb distance isn't designed for anyway.
     assume(plane.dip_dir >= plane.strike + 1)
+    assume(plane.dip != 90)
     buffer = shapely.buffer(plane.geometry, distance * 1000)
     for point in coordinates.nztm_to_wgs_depth(np.array(buffer.exterior.coords)):
         assert np.isclose(
@@ -350,18 +442,7 @@ def test_plane_rjb(plane: Plane, distance: float):
 
 
 @given(
-    plane=st.builds(
-        fault_plane,
-        length=st.floats(0.1, 1000),
-        projected_width=st.floats(0.1, 1000),
-        strike=st.floats(0, 179),
-        dip_dir=st.floats(1, 179),
-        top=st.floats(0, 100),
-        depth=st.floats(0.1, 100),
-        centroid=st.builds(
-            coordinate, lat=st.floats(-50, -31), lon=st.floats(160, 180)
-        ),
-    ),
+    plane=fault_plane,
     local_coordinates=nst.arrays(
         float, (2,), elements={"min_value": 0, "max_value": 1}
     ),
@@ -474,7 +555,6 @@ def test_fault_rrup(fault: Fault, point: np.ndarray):
 )
 def test_fault_construction(fault: Fault):
     assert fault.width == fault.planes[0].width
-    assert np.isclose(fault.dip_dir, fault.planes[0].strike + 90)
     assert fault.corners.shape == (4 * len(fault.planes), 3)
     assert np.isclose(fault.area(), np.sum([plane.area for plane in fault.planes]))
     assert fault.geometry.equals(

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -226,11 +226,11 @@ def test_plane_construction(
     assume(valid_coordinates(centroid))
     plane = Plane.from_centroid_strike_dip(
         centroid,
-        strike,
         dip,
-        dip_dir,
         length,
         width,
+        strike_nztm=strike,
+        dip_dir_nztm=dip_dir,
     )
     assert np.isclose(plane.length, length, atol=1e-6)
     assert np.isclose(plane.width, width, atol=1e-6)
@@ -324,7 +324,14 @@ def test_from_centroid_strike_dip_failure_cases(
 ):
     with pytest.raises(ValueError):
         Plane.from_centroid_strike_dip(
-            centroid, strike, dip, dip_dir, length, width, dtop, dbottom
+            centroid,
+            dip,
+            length,
+            width,
+            dtop=dtop,
+            dbottom=dbottom,
+            strike_nztm=strike,
+            dip_dir_nztm=dip_dir,
         )
 
 
@@ -352,7 +359,14 @@ def test_from_centroid_strike_dip_dtop_dbottom_derivation(
     expected_dbottom,
 ):
     plane = Plane.from_centroid_strike_dip(
-        centroid, strike, dip, dip_dir, length, width, dtop, dbottom
+        centroid,
+        dip,
+        length,
+        width,
+        dtop=dtop,
+        dbottom=dbottom,
+        strike_nztm=strike,
+        dip_dir_nztm=dip_dir,
     )
     assert np.isclose(plane.corners[0, -1], expected_dtop * 1000)
     assert np.isclose(plane.corners[-1, -1], expected_dbottom * 1000)
@@ -368,8 +382,8 @@ fault_plane = st.builds(
     ),
     length=st.floats(0.1, 1000),
     width=st.floats(0.1, 1000),
-    strike=st.floats(0, 179),
-    dip_dir=st.floats(5, 179),
+    strike_nztm=st.floats(0, 179),
+    dip_dir_nztm=st.floats(5, 179),
     dip=st.floats(0.1, 90),
 )
 

--- a/tests/test_srf.py
+++ b/tests/test_srf.py
@@ -82,6 +82,16 @@ def test_christchurch_srf():
         5.52983e00,
         1.62786e00,
     ]
+    for (_, header), plane in zip(
+        christchurch_srf.header.iterrows(), christchurch_srf.planes
+    ):
+        assert header[["elat", "elon"]].values == pytest.approx(plane.centroid[:2])
+        assert header["wid"] == pytest.approx(plane.width)
+        assert header["len"] == pytest.approx(plane.length)
+        assert header["len"] == pytest.approx(plane.length)
+        assert header["dip"] == pytest.approx(plane.dip)
+        assert header["stk"] == pytest.approx(plane.strike, abs=0.1)
+        assert header["dtop"] == pytest.approx(plane.corners[0, -1] / 1000)
 
 
 def test_darfield_srf():
@@ -190,6 +200,15 @@ def test_darfield_srf():
         assert len(segment) == segment_header["nstk"] * segment_header["ndip"]
         assert (segment["dip"] == segment_header["dip"]).all()
         assert (segment["stk"] == segment_header["stk"]).all()
+    for (_, header), plane in zip(darfield_srf.header.iterrows(), darfield_srf.planes):
+        assert header[["elat", "elon"]].values == pytest.approx(plane.centroid[:2])
+        assert header["wid"] == pytest.approx(plane.width)
+        assert header["len"] == pytest.approx(plane.length)
+        assert header["len"] == pytest.approx(plane.length)
+        # the dip in the Darfield SRF makes no sense!
+        # assert header["dip"] == pytest.approx(plane.dip)
+        assert header["stk"] == pytest.approx(plane.strike, abs=0.1)
+        assert header["dtop"] == pytest.approx(plane.corners[0, -1] / 1000)
 
 
 def test_junk_srfs():


### PR DESCRIPTION
### Enhancements to `Plane` class:
* Added new properties `strike`, `strike_nztm`, `dip_dir`, and `dip_dir_nztm` to the `Plane` class to handle different coordinate systems and bearings. (`source_modelling/sources.py`) [[1]](diffhunk://#diff-5f2630533f745c6079637bcfdab384f3d08c41a5b14c36173b4dbc55423dc984R291-R297) [[2]](diffhunk://#diff-5f2630533f745c6079637bcfdab384f3d08c41a5b14c36173b4dbc55423dc984R308-R314)
* Refactored the `from_centroid_strike_dip` method to include additional parameters such as `strike_nztm` and `dip_dir_nztm` and added comprehensive validation checks for input consistency. (`source_modelling/sources.py`) [[1]](diffhunk://#diff-5f2630533f745c6079637bcfdab384f3d08c41a5b14c36173b4dbc55423dc984L326-R348) [[2]](diffhunk://#diff-5f2630533f745c6079637bcfdab384f3d08c41a5b14c36173b4dbc55423dc984L342-R477)

### SRF Module:
* Added a new property `planes` to the `segments` method to extract planes from SRF segments. (`source_modelling/srf.py`)

### Test Coverage:

* Added new test cases to validate the construction of `Plane` objects, including failure cases for invalid input combinations and parameter derivations. (`tests/test_sources.py`) [[1]](diffhunk://#diff-3cd5d0943d234b07cb43ae8d4ddb6ac1030183923dc4d6cd56e528f646e48ecdR4) [[2]](diffhunk://#diff-3cd5d0943d234b07cb43ae8d4ddb6ac1030183923dc4d6cd56e528f646e48ecdL206-R392) [[3]](diffhunk://#diff-3cd5d0943d234b07cb43ae8d4ddb6ac1030183923dc4d6cd56e528f646e48ecdL299-R426)
* Updated existing test cases to reflect the changes in the `Plane` class and its methods. (`tests/test_sources.py`) [[1]](diffhunk://#diff-3cd5d0943d234b07cb43ae8d4ddb6ac1030183923dc4d6cd56e528f646e48ecdL326-R448) [[2]](diffhunk://#diff-3cd5d0943d234b07cb43ae8d4ddb6ac1030183923dc4d6cd56e528f646e48ecdL353-R459) [[3]](diffhunk://#diff-3cd5d0943d234b07cb43ae8d4ddb6ac1030183923dc4d6cd56e528f646e48ecdL477)
* Added assertions to verify the consistency of SRF header data with the newly introduced `planes` property. (`tests/test_srf.py`) [[1]](diffhunk://#diff-931748e37d1fdd2a8b0e2329f848e06a857c9df6cc8f5475138abf9b2af6134eR85-R94) [[2]](diffhunk://#diff-931748e37d1fdd2a8b0e2329f848e06a857c9df6cc8f5475138abf9b2af6134eR203-R211)