### PR TITLE
Use depth information if dip = 90

### DIFF
--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -617,10 +617,18 @@ class Plane:
         ValueError
             If the given coordinates do not lie in the fault plane.
         """
-        strike_direction = self.bounds[1, :2] - self.bounds[0, :2]
-        dip_direction = self.bounds[-1, :2] - self.bounds[0, :2]
+        coordinate_length = (
+            3 if global_coordinates.shape[-1] == 3 or self.dip == 90 else 2
+        )
+        strike_direction = (
+            self.bounds[1, :coordinate_length] - self.bounds[0, :coordinate_length]
+        )
+        dip_direction = (
+            self.bounds[-1, :coordinate_length] - self.bounds[0, :coordinate_length]
+        )
         offset = (
-            coordinates.wgs_depth_to_nztm(global_coordinates[:2]) - self.bounds[0, :2]
+            coordinates.wgs_depth_to_nztm(global_coordinates[:coordinate_length])
+            - self.bounds[0, :coordinate_length]
         )
         fault_local_coordinates, _, _, _ = np.linalg.lstsq(
             np.array([strike_direction, dip_direction]).T, offset, rcond=None

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -616,6 +616,13 @@ class Plane:
         ------
         ValueError
             If the given coordinates do not lie in the fault plane.
+
+        Notes
+        -----
+        While not passing depth information is supported, depth information
+        *greatly* improves the accuracy of the estimation. No guarantees
+        are made about the accuracy of the inversion if you do not pass
+        depth information.
         """
         coordinate_length = (
             3 if global_coordinates.shape[-1] == 3 or self.dip == 90 else 2
@@ -633,14 +640,15 @@ class Plane:
         fault_local_coordinates, _, _, _ = np.linalg.lstsq(
             np.array([strike_direction, dip_direction]).T, offset, rcond=None
         )
+        tolerance = 1e-6 if coordinate_length == 3 else 1e-4
         if not np.all(
             (
                 (fault_local_coordinates > 0)
-                | np.isclose(fault_local_coordinates, 0, atol=1e-6)
+                | np.isclose(fault_local_coordinates, 0, atol=tolerance)
             )
             & (
                 (fault_local_coordinates < 1)
-                | np.isclose(fault_local_coordinates, 1, atol=1e-6)
+                | np.isclose(fault_local_coordinates, 1, atol=tolerance)
             )
         ):
             raise ValueError("Specified coordinates do not lie in plane")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import scipy as sp
 import shapely
-from hypothesis import assume, given, reproduce_failure, seed, settings
+from hypothesis import assume, given, seed, settings
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as nst
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -530,25 +530,6 @@ def test_plane_coordinate_inversion(plane: Plane, local_coordinates: np.ndarray)
     )
 
 
-@given(
-    plane=fault_plane,
-    local_coordinates=nst.arrays(
-        float, (2,), elements={"min_value": 0, "max_value": 1}
-    ),
-)
-@seed(1)
-def test_plane_coordinate_inversion(plane: Plane, local_coordinates: np.ndarray):
-    """Test the inversion of coordinate transformations for a Plane object."""
-    assume(not np.isclose(plane.dip_dir, plane.strike))
-    assert np.allclose(
-        plane.wgs_depth_coordinates_to_fault_coordinates(
-            plane.fault_coordinates_to_wgs_depth_coordinates(local_coordinates)
-        ),
-        local_coordinates,
-        atol=1e-6,
-    )
-
-
 def connected_fault(
     lengths: list[float], width: float, strike: float, start_coordinates: np.ndarray
 ) -> Fault:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import scipy as sp
 import shapely
-from hypothesis import assume, given, seed, settings
+from hypothesis import assume, given, reproduce_failure, seed, settings
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as nst
 
@@ -577,6 +577,7 @@ def connected_fault(
         ),
     )
 )
+@settings(deadline=None)
 def test_fault_reordering(fault: Fault):
     """Ensure that the plane order in faults is completely determined by the planes."""
     for order in itertools.permutations(range(len(fault.planes))):
@@ -658,31 +659,6 @@ def test_fault_construction(fault: Fault):
     assert np.allclose(
         fault.wgs_depth_coordinates_to_fault_coordinates(fault.centroid),
         np.array([1 / 2, 1 / 2]),
-    )
-
-
-@given(
-    fault=fault_plane,
-    local_coordinates=nst.arrays(
-        float, (2,), elements={"min_value": 0, "max_value": 1}
-    ),
-)
-def test_fault_coordinate_depth_irrelevance(
-    fault: Fault, local_coordinates: np.ndarray
-):
-    """Test that the depth information is irrelevant if dip != 90."""
-    assume(fault.dip < 89)
-    global_coordinates = fault.fault_coordinates_to_wgs_depth_coordinates(
-        local_coordinates
-    )
-
-    assert np.allclose(
-        fault.wgs_depth_coordinates_to_fault_coordinates(global_coordinates[:2]),
-        local_coordinates,
-    )
-    assert np.allclose(
-        fault.wgs_depth_coordinates_to_fault_coordinates(global_coordinates),
-        local_coordinates,
     )
 
 


### PR DESCRIPTION
This PR changes the behaviour of `plane.wgs_depth_coordinates_to_fault_coordinates`, which converts WGS84 coordinates to coordinates in the fault.

# Old Behaviour

The old behaviour used the corner coordinates of the plane to find the fault local coordinates, **without using the depth information**. Ignoring the depth is desirable for two reasons:

1. If `dip != 90`, then this information is redundant, and removing the depth improves the numerical stability of the linear algebra used to derive the local strike and dip coordinates.
2. This method is often used for finding converting hypocentre locations to fault local coordinates for simulations. Often the depth is not quite on the plane, or is rounded, which results in errors in the approximation of the fault-local point (see the diagram below). 

However, it means that the method fails if `dip = 90`.

# New Behaviour
The new behaviour will now account for the depth of the point in two cases:

1. When `dip = 90`,
2. If the user provides global coordinates with a depth component.
