### PR TITLE
Check rupture propagation graph is connected.

### DIFF
--- a/source_modelling/rupture_propagation.py
+++ b/source_modelling/rupture_propagation.py
@@ -96,7 +96,14 @@ def sampled_spanning_tree(
     -------
     list[nx.Graph] or nx.Graph
         A list of sampled spanning trees, or a graph if `n_samples = 1`.
+
+    Raises
+    ------
+    ValueError
+        If `graph` is not connected.
     """
+    if not nx.is_connected(graph):
+        raise ValueError("The graph must be connected to find a spanning tree.")
     weight_graph = graph.copy()
     for u, v in weight_graph.edges:
         weight_graph[u][v]["weight"] /= 1 - weight_graph[u][v]["weight"]
@@ -230,8 +237,14 @@ def most_likely_spanning_tree(graph: nx.Graph) -> nx.Graph:
     -------
     nx.Graph
         The most likely maximum spanning tree for this graph.
-    """
 
+    Raises
+    ------
+    ValueError
+        If `graph` is not connected.
+    """
+    if not nx.is_connected(graph):
+        raise ValueError("The graph must be connected to find a spanning tree.")
     weighted_graph = graph.copy()
 
     # See `select_top_spanning_trees` for an explanation of what the following

--- a/tests/test_rupture_propagation.py
+++ b/tests/test_rupture_propagation.py
@@ -41,6 +41,29 @@ def graph_repr(graph: nx.Graph) -> str:
 
 
 @pytest.mark.parametrize(
+    "graph",
+    [
+        nx.from_edgelist(
+            [
+                (0, 1, {"weight": 0.482}),
+                (0, 2, {"weight": 0.387}),
+                (3, 4, {"weight": 0.473}),
+            ]
+        )
+    ],
+)
+def test_disconnected_graph(graph: nx.Graph):
+    with pytest.raises(
+        ValueError, match="The graph must be connected to find a spanning tree."
+    ):
+        rupture_propagation.most_likely_spanning_tree(graph)
+    with pytest.raises(
+        ValueError, match="The graph must be connected to find a spanning tree."
+    ):
+        rupture_propagation.sampled_spanning_tree(graph, 1)
+
+
+@pytest.mark.parametrize(
     "graph,n",
     [
         (


### PR DESCRIPTION
This PR addresses some problems I had when the rupture propagation would find a rupture causality tree that did not include every fault because the graph was not connected. This was only a problem with the broken geometry given by the nshmdb package, but this still feels like an edge case worth addressing.
