### PR TITLE
Add options to set plot dimensions

### DIFF
--- a/source_modelling/scripts/plot_mw_contributions.py
+++ b/source_modelling/scripts/plot_mw_contributions.py
@@ -30,6 +30,8 @@ def plot_mw_contributions(
     dpi: Annotated[
         float, typer.Option(help="Output plot DPI (higher is better).")
     ] = 300,
+    height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
 ) -> None:
     """Plot segment magnitudes against the Leonard scaling relation.
 
@@ -43,6 +45,10 @@ def plot_mw_contributions(
         Output plot path.
     dpi : float, default 300
         Output plot DPI (higher is better).
+    width : float
+        Width of plot (in cm).
+    height : float
+        Height of plot (in cm).
     """
     source_config = SourceConfig.read_from_realisation(realisation_ffp)
     rupture_propogation_config = RupturePropagationConfig.read_from_realisation(
@@ -55,6 +61,8 @@ def plot_mw_contributions(
     )
     area = np.linspace(smallest_area, total_area)
     fig, ax = plt.subplots()
+    cm = 1 / 2.54
+    fig.set_size_inches(width * cm, height * cm)
     # Mw = log(area) + 3.995 is the Leonard2014 magnitude scaling relation
     # for average rake.
     ax.plot(

--- a/source_modelling/scripts/plot_mw_contributions.py
+++ b/source_modelling/scripts/plot_mw_contributions.py
@@ -31,7 +31,7 @@ def plot_mw_contributions(
         float, typer.Option(help="Output plot DPI (higher is better).")
     ] = 300,
     height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
-    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot width (cm)", min=0)] = 10,
 ) -> None:
     """Plot segment magnitudes against the Leonard scaling relation.
 

--- a/source_modelling/scripts/plot_rakes.py
+++ b/source_modelling/scripts/plot_rakes.py
@@ -33,8 +33,7 @@ def plot_rakes(
     seed: Annotated[
         Optional[int], typer.Option(help="Random seed to sample rakes with")
     ] = None,
-    height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
-    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot width (cm)", min=0)] = 17,
 ) -> None:
     """Plot an SRF file and output a PNG file.
 
@@ -54,8 +53,6 @@ def plot_rakes(
         Length of rake vectors (cm).
     width : float
         Width of plot (in cm).
-    height : float
-        Height of plot (in cm).
     """
     srf_data = srf.read_srf(srf_ffp)
     region = (
@@ -65,9 +62,9 @@ def plot_rakes(
         srf_data.points["lat"].max() + 0.25,
     )
 
-    fig = plotting.gen_region_fig(title, region=region, map_data=None)
-    cm = 1 / 2.54
-    fig.set_size_inches(width * cm, height * cm)
+    fig = plotting.gen_region_fig(
+        title, projection=f"M{width}c", region=region, map_data=None
+    )
     i = 0
 
     np.random.seed(seed)

--- a/source_modelling/scripts/plot_rakes.py
+++ b/source_modelling/scripts/plot_rakes.py
@@ -33,6 +33,8 @@ def plot_rakes(
     seed: Annotated[
         Optional[int], typer.Option(help="Random seed to sample rakes with")
     ] = None,
+    height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
 ) -> None:
     """Plot an SRF file and output a PNG file.
 
@@ -50,6 +52,10 @@ def plot_rakes(
         Number of points to sample for rake.
     vector_length : float, default 0.2cm
         Length of rake vectors (cm).
+    width : float
+        Width of plot (in cm).
+    height : float
+        Height of plot (in cm).
     """
     srf_data = srf.read_srf(srf_ffp)
     region = (
@@ -60,6 +66,8 @@ def plot_rakes(
     )
 
     fig = plotting.gen_region_fig(title, region=region, map_data=None)
+    cm = 1 / 2.54
+    fig.set_size_inches(width * cm, height * cm)
     i = 0
 
     np.random.seed(seed)

--- a/source_modelling/scripts/plot_rise.py
+++ b/source_modelling/scripts/plot_rise.py
@@ -23,8 +23,7 @@ def plot_rise(
         float, typer.Option(help="Plot output DPI (higher is better)")
     ] = 300,
     title: Annotated[Optional[str], typer.Option(help="Plot title to use")] = None,
-    height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
-    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot width (cm)", min=0)] = 17,
 ) -> None:
     """Plot multi-segment drupture with rise.
 
@@ -38,6 +37,8 @@ def plot_rise(
         Plot output DPI (higher is better).
     title : Optional[str], default None
         Plot title to use.
+    width : float
+        Width of plot (in cm).
     """
     srf_data = srf.read_srf(srf_ffp)
     region = (
@@ -54,9 +55,9 @@ def plot_rise(
     trise_cb_max = srf_data.points["trise"].max()
     cmap_limits = (0, trise_cb_max, trise_cb_max / 10)
 
-    fig = plotting.gen_region_fig(title, region=region, map_data=None)
-    cm = 1 / 2.54
-    fig.set_size_inches(width * cm, height * cm)
+    fig = plotting.gen_region_fig(
+        title, projection=f"M{width}c", region=region, map_data=None
+    )
 
     for i, segment_points in enumerate(srf_data.segments):
         cur_grid = plotting.create_grid(

--- a/source_modelling/scripts/plot_rise.py
+++ b/source_modelling/scripts/plot_rise.py
@@ -23,6 +23,8 @@ def plot_rise(
         float, typer.Option(help="Plot output DPI (higher is better)")
     ] = 300,
     title: Annotated[Optional[str], typer.Option(help="Plot title to use")] = None,
+    height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
 ) -> None:
     """Plot multi-segment drupture with rise.
 
@@ -53,6 +55,9 @@ def plot_rise(
     cmap_limits = (0, trise_cb_max, trise_cb_max / 10)
 
     fig = plotting.gen_region_fig(title, region=region, map_data=None)
+    cm = 1 / 2.54
+    fig.set_size_inches(width * cm, height * cm)
+
     for i, segment_points in enumerate(srf_data.segments):
         cur_grid = plotting.create_grid(
             segment_points,

--- a/source_modelling/scripts/plot_srf.py
+++ b/source_modelling/scripts/plot_srf.py
@@ -44,6 +44,8 @@ def plot_srf(
         float, typer.Option(help="longitude padding to apply (degrees)")
     ] = 0,
     annotations: Annotated[bool, typer.Option(help="Label contours")] = True,
+    height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
 ) -> None:
     """Plot multi-segment rupture with slip.
 
@@ -67,6 +69,10 @@ def plot_srf(
         Longitude padding to apply (degrees).
     annotations : bool
         Label contours.
+    width : float
+        Width of plot (in cm).
+    height : float
+        Height of plot (in cm).
     """
     srf_data = srf.read_srf(srf_ffp)
 
@@ -83,6 +89,9 @@ def plot_srf(
     cmap_limits = (0, slip_cb_max, slip_cb_max / 10)
 
     fig = plotting.gen_region_fig(title, region=region, map_data=None)
+
+    cm = 1 / 2.54
+    fig.set_size_inches(width * cm, height * cm)
 
     for (_, segment), segment_points in zip(
         srf_data.header.iterrows(), srf_data.segments

--- a/source_modelling/scripts/plot_srf.py
+++ b/source_modelling/scripts/plot_srf.py
@@ -44,8 +44,7 @@ def plot_srf(
         float, typer.Option(help="longitude padding to apply (degrees)")
     ] = 0,
     annotations: Annotated[bool, typer.Option(help="Label contours")] = True,
-    height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
-    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot width (cm)", min=0)] = 17,
 ) -> None:
     """Plot multi-segment rupture with slip.
 
@@ -71,8 +70,6 @@ def plot_srf(
         Label contours.
     width : float
         Width of plot (in cm).
-    height : float
-        Height of plot (in cm).
     """
     srf_data = srf.read_srf(srf_ffp)
 
@@ -88,10 +85,9 @@ def plot_srf(
     slip_cb_max = max(int(np.round(slip_quantile, -1)), 10)
     cmap_limits = (0, slip_cb_max, slip_cb_max / 10)
 
-    fig = plotting.gen_region_fig(title, region=region, map_data=None)
-
-    cm = 1 / 2.54
-    fig.set_size_inches(width * cm, height * cm)
+    fig = plotting.gen_region_fig(
+        title, projection=f"M{width}c", region=region, map_data=None
+    )
 
     for (_, segment), segment_points in zip(
         srf_data.header.iterrows(), srf_data.segments

--- a/source_modelling/scripts/plot_srf_cumulative_moment.py
+++ b/source_modelling/scripts/plot_srf_cumulative_moment.py
@@ -39,7 +39,7 @@ def plot_srf_cumulative_moment(
         float, typer.Option(help="Maximum shading cutoff", min=0, max=1)
     ] = 0.95,
     height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
-    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot width (cm)", min=0)] = 10,
 ):
     """Plot cumulative moment for an SRF over time.
 

--- a/source_modelling/scripts/plot_srf_cumulative_moment.py
+++ b/source_modelling/scripts/plot_srf_cumulative_moment.py
@@ -38,6 +38,8 @@ def plot_srf_cumulative_moment(
     max_shade_cutoff: Annotated[
         float, typer.Option(help="Maximum shading cutoff", min=0, max=1)
     ] = 0.95,
+    height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
 ):
     """Plot cumulative moment for an SRF over time.
 
@@ -56,6 +58,10 @@ def plot_srf_cumulative_moment(
         Minimum shading cutoff.
     max_shade_cutoff : Annotated[ float, typer.Option(help
         Maximum shading cutoff.
+    width : float
+        Width of plot (in cm).
+    height : float
+        Height of plot (in cm).
     """
     srf_data = srf.read_srf(srf_ffp)
 
@@ -74,6 +80,8 @@ def plot_srf_cumulative_moment(
         & (overall_moment["moment"] <= total_moment * max_shade_cutoff)
     ]
     fig, ax = plt.subplots()
+    cm = 1 / 2.54
+    fig.set_size_inches(width * cm, height * cm)
     ax.fill_between(shaded_moments.index.values, shaded_moments["moment"], alpha=0.2)
     ax.plot(
         overall_moment.index.values, overall_moment["moment"], label="Overall Moment"

--- a/source_modelling/scripts/plot_srf_moment.py
+++ b/source_modelling/scripts/plot_srf_moment.py
@@ -31,6 +31,8 @@ def plot_srf_moment(
             help="Path to realisation, used to plot individual fault contribution."
         ),
     ] = None,
+    height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
 ) -> None:
     """Plot released moment for an SRF over time.
 
@@ -44,6 +46,10 @@ def plot_srf_moment(
         Plot image pixel density (higher = better).
     realisation_ffp : Optional[Path], default None
         Path to realisation, used to plot individual fault contribution.
+    width : float
+        Width of plot (in cm).
+    height : float
+        Height of plot (in cm).
     """
     srf_data = srf.read_srf(srf_ffp)
 
@@ -57,6 +63,8 @@ def plot_srf_moment(
         srf_data.points["area"], srf_data.slip, dt, srf_data.nt
     )
     fig, ax = plt.subplots()
+    cm = 1 / 2.54
+    fig.set_size_inches(width * cm, height * cm)
     ax.plot(
         overall_moment_rate.index.values,
         overall_moment_rate["moment_rate"],

--- a/source_modelling/scripts/plot_srf_moment.py
+++ b/source_modelling/scripts/plot_srf_moment.py
@@ -32,7 +32,7 @@ def plot_srf_moment(
         ),
     ] = None,
     height: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
-    width: Annotated[float, typer.Option(help="Plot height (cm)", min=0)] = 10,
+    width: Annotated[float, typer.Option(help="Plot width (cm)", min=0)] = 10,
 ) -> None:
     """Plot released moment for an SRF over time.
 


### PR DESCRIPTION
PR just adds `--height` and `--width` options to every CLI plotting tool to set the width and height of matplotlib plots in centimetres.
