### PR TITLE
Add multi-segment parsing capabalities

### DIFF
--- a/source_modelling/fsp.py
+++ b/source_modelling/fsp.py
@@ -20,8 +20,8 @@ Example
 """
 
 import dataclasses
-import re
 import io
+import re
 from pathlib import Path
 from typing import Callable, Optional
 

--- a/source_modelling/fsp.py
+++ b/source_modelling/fsp.py
@@ -336,7 +336,7 @@ def _parse_velocity_density_structure(
     """
     # Matches % No. of layers = x, where x is the number of layers in the velocity model.
     number_of_layers_re = re.match(
-        r"% No\. of layers\s*=\s*(\d+)", next(fsp_file_handle)
+        r"%\s+No\.\s+of\s+layers\s*=\s*(\d+)", next(fsp_file_handle)
     )
     layer_count = 0
     if number_of_layers_re:
@@ -349,7 +349,9 @@ def _parse_velocity_density_structure(
     while line := next(fsp_file_handle):
         if re.match(r"%\s+DEPTH\s+P-VEL", line):
             uses_velocity_model_table = True
-            columns = re.split(r"\s+", line.strip("% "))
+            columns = [
+                column for column in re.split(r"\s+", line.strip("% ")) if column
+            ]
             break
         elif "shear modulus" in line.lower():
             # This is the case for an assumed constant mu value for the whole

--- a/source_modelling/fsp.py
+++ b/source_modelling/fsp.py
@@ -23,7 +23,7 @@ import dataclasses
 import io
 import re
 from pathlib import Path
-from typing import Callable, Optional, IO
+from typing import IO, Callable, Optional
 
 import pandas as pd
 import parse

--- a/source_modelling/fsp.py
+++ b/source_modelling/fsp.py
@@ -383,7 +383,25 @@ def _parse_velocity_density_structure(
         lines = io.StringIO(
             "\n".join([next(fsp_file_handle).strip("% ") for _ in range(layer_count)])
         )
-        return pd.read_csv(lines, delimiter=r"\s+", header=None, names=columns)
+        df = pd.read_csv(lines, delimiter=r"\s+", header=None, names=columns)
+        bad_columns = []
+
+        for column in df.columns:
+            if (df[column].abs() == 999).all() or (df[column].abs() == 9999).all():
+                bad_columns.append(column)
+        if bad_columns:
+            df = df.drop(columns=bad_columns)
+
+        return df.rename(
+            columns={
+                "DEPTH": "depth",
+                "P-VEL": "Vp",
+                "S-VEL": "Vs",
+                "QP": "Qp",
+                "QS": "Qs",
+                "DENS": "density",
+            }
+        )
 
     # Parse out the assumed shear modulus
     # It is split over two lines, a scale which looks like % [10**10 N/m^2]

--- a/source_modelling/fsp.py
+++ b/source_modelling/fsp.py
@@ -28,7 +28,6 @@ from typing import Callable, Optional
 import pandas as pd
 import parse
 
-# Adapted from regex: https://stackoverflow.com/a/4703508
 HEADER_PATTERN = """EventTAG: {event_tag}
 Loc : LAT = {latitude:g} LON = {longitude:g} DEP = {depth:g}
 Size : LEN = {length:g} km WID = {width:g} km Mw = {magnitude:g} Mo = {moment:g} Nm

--- a/source_modelling/fsp.py
+++ b/source_modelling/fsp.py
@@ -344,11 +344,12 @@ def _parse_velocity_density_structure(
     else:
         return None
 
-    columns = ["DEPTH", "P-VEL", "S-VEL", "QP", "QS"]
+    columns = []
     uses_velocity_model_table = False
     while line := next(fsp_file_handle):
         if re.match(r"%\s+DEPTH\s+P-VEL", line):
             uses_velocity_model_table = True
+            columns = re.split(r"\s+", line.strip("% "))
             break
         elif "shear modulus" in line.lower():
             # This is the case for an assumed constant mu value for the whole

--- a/tests/test_fsp.py
+++ b/tests/test_fsp.py
@@ -40,6 +40,7 @@ def test_darfield_fsp():
     assert fsp_file.segment_count == 8
     assert len(fsp_file.data) == 886
     assert fsp_file.data.iloc[0].to_dict() == {
+        "segment": 0,
         "lat": -43.5965,
         "lon": 172.0673,
         "x": -10.6899,
@@ -127,8 +128,11 @@ def test_loads_srcmod_fsp(fsp_path: Path):
         assert fsp_file.nx > 0, f"nx should be positive, got {fsp_file.nx}"
     if fsp_file.nz is not None:
         assert fsp_file.nz > 0, f"nz should be positive, got {fsp_file.nz}"
-    assert fsp_file.dx > 0, f"dx should be positive, got {fsp_file.dx}"
-    assert fsp_file.dz > 0, f"dz should be positive, got {fsp_file.dz}"
+
+    if fsp_file.dx is not None:
+        assert fsp_file.dx > 0, f"dx should be positive, got {fsp_file.dx}"
+    if fsp_file.dz is not None:
+        assert fsp_file.dz > 0, f"dz should be positive, got {fsp_file.dz}"
 
     # Inversion parameters bounds
     if fsp_file.fmin is not None:
@@ -166,6 +170,7 @@ def test_loads_srcmod_fsp(fsp_path: Path):
 
     # Check that there is at least one row in the data
     assert fsp_file.data.shape[0] > 0, "data DataFrame should have at least one row"
+    assert fsp_file.data["segment"].max() == fsp_file.segment_count - 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fsp.py
+++ b/tests/test_fsp.py
@@ -47,7 +47,103 @@ def test_darfield_fsp():
         "y": -5.1682,
         "z": 0.0000,
         "slip": 4.8065,
+        "length": 10.0,
+        "width": 10.0,
     }
+    assert fsp_file.velocity_model is None
+
+
+def test_kanto_fsp():
+    """Check that the Kanto FSP file is parsed with the correct values extracted."""
+    fsp_file = fsp.FSPFile.read_from_file(FSP_PATH / "s1923KANTOJkoba.fsp")
+    assert fsp_file.event_tag == "s1923KANTOJkoba"
+    assert fsp_file.latitude == 35.400
+    assert fsp_file.longitude == 139.200
+    assert fsp_file.depth == 14.60
+    assert fsp_file.hypx == 110.50
+    assert fsp_file.hypz == 35.00
+    assert fsp_file.length == 130.00
+    assert fsp_file.width == 70.00
+    assert fsp_file.strike == 290
+    assert fsp_file.dip == 25
+    assert fsp_file.rake == 140
+    assert fsp_file.htop == 2.00
+    assert fsp_file.magnitude == 8.08
+    assert fsp_file.moment == 1.46e21
+    assert fsp_file.average_rise_time == 10.5
+    assert fsp_file.average_rupture_speed == 2.6
+    assert fsp_file.slip_velocity_function == "triang"
+    assert fsp_file.nx == 10
+    assert fsp_file.nz == 7
+    assert fsp_file.dx == 13.00
+    assert fsp_file.dz == 10.00
+    assert fsp_file.fmin == 0.02
+    assert fsp_file.fmax == 0.4
+    assert fsp_file.time_window_count == 1
+    assert fsp_file.time_window_length == 1.50
+    assert fsp_file.time_shift == 0.00
+    assert fsp_file.segment_count == 1
+    assert len(fsp_file.data) == 70
+    assert fsp_file.data.iloc[0].to_dict() == {
+        "segment": 0,
+        "lat": 34.812,
+        "lon": 140.159,
+        "x": 86.879,
+        "y": -65.378,
+        "z": 2.000,
+        "slip": 2.585,
+    }
+    expected_velocity_model = pd.DataFrame(
+        [
+            {"depth": 0.00, "Vp": 5.60, "Vs": 2.90, "density": 2.50},
+            {"depth": 6.10, "Vp": 6.00, "Vs": 3.40, "density": 2.60},
+            {"depth": 19.00, "Vp": 6.80, "Vs": 4.00, "density": 3.00},
+        ]
+    )
+    pd.testing.assert_frame_equal(fsp_file.velocity_model, expected_velocity_model)
+
+
+def test_nankaido_fsp():
+    """Check that the Nankaido FSP file is parsed with the correct values extracted."""
+    fsp_file = fsp.FSPFile.read_from_file(FSP_PATH / "s1946NANKAItani.fsp")
+    assert fsp_file.event_tag == "s1946NANKAItani"
+    assert fsp_file.latitude == 33.030
+    assert fsp_file.longitude == 135.620
+    assert fsp_file.depth == 30.00
+    assert fsp_file.hypx == 90.00
+    assert fsp_file.hypz == 45.00
+    assert fsp_file.length == 360.00
+    assert fsp_file.width == 180.00
+    assert fsp_file.strike == 250
+    assert fsp_file.dip == 13
+    assert fsp_file.rake == 120
+    assert fsp_file.htop == 1.00
+    assert fsp_file.magnitude == 8.40
+    assert fsp_file.moment == 4.51e21
+    assert fsp_file.average_rise_time == 0.0
+    assert fsp_file.average_rupture_speed == 0.0
+    assert fsp_file.slip_velocity_function == "tsunami modeling"
+    assert fsp_file.nx == 8
+    assert fsp_file.nz == 4
+    assert fsp_file.dx == 45.00
+    assert fsp_file.dz == 45.00
+    assert fsp_file.fmin == 0.00
+    assert fsp_file.fmax == 0.0
+    assert fsp_file.time_window_count == 0
+    assert fsp_file.time_window_length == 0.00
+    assert fsp_file.time_shift == 0.00
+    assert fsp_file.segment_count == 1
+    assert len(fsp_file.data) == 32
+    assert fsp_file.data.iloc[0].to_dict() == {
+        "segment": 0,
+        "lat": 32.867,
+        "lon": 136.462,
+        "x": 78.426,
+        "y": -18.116,
+        "z": 1.000,
+        "slip": 0.850,
+    }
+    assert fsp_file.velocity_model == 3.3e10
 
 
 FSPS = list(FSP_PATH.glob("*.fsp"))
@@ -170,6 +266,7 @@ def test_loads_srcmod_fsp(fsp_path: Path):
 
     # Check that there is at least one row in the data
     assert fsp_file.data.shape[0] > 0, "data DataFrame should have at least one row"
+    # Check the number of segments matches the reported value in the header.
     assert fsp_file.data["segment"].max() == fsp_file.segment_count - 1
 
 


### PR DESCRIPTION
This PR adds the ability to extract all the segments of an FSP file, by adding a segment column to the dataframe containing the slip model in the FSP file. See [list of multi-segment models with TRUP](https://uceqeng.slack.com/archives/C06L1MRUQF8/p1738638832342899) on Slack for examples of these kinds of models.