### PR TITLE
Support SRF segment recovery where min(nstk, ndip) == 1

### DIFF
--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -57,7 +57,7 @@ import pandas as pd
 import scipy as sp
 import shapely
 
-from qcore import coordinates, geo
+from qcore import coordinates
 from source_modelling import srf_reader
 from source_modelling.sources import Plane
 


### PR DESCRIPTION
This PR adds support for the recovery of the geometry from an SRF file in the case where the SRF contains short segments. Short segments are segments with either `nstk = 1` or `ndip = 1`. In this case the SRF header must be relied on for at least one of the coordinate values.