### PR TITLE
Add support to read rise time from SRF

### DIFF
--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -401,7 +401,9 @@ class Plane:
 
     @property
     def geometry(self) -> shapely.Polygon | shapely.LineString:  # numpydoc ignore=RT01
-        """shapely.Polygon: A shapely geometry for the plane (projected onto the surface)."""
+        """shapely.Polygon or LineString: A shapely geometry for the plane (projected onto the surface).
+
+        Geometry will be a LineString if `dip = 90`."""
         if self.dip == 90:
             return shapely.LineString(self.bounds[:2])
         return shapely.Polygon(self.bounds)
@@ -1051,8 +1053,11 @@ class Fault:
         return self.fault_coordinates_to_wgs_depth_coordinates(np.array([1 / 2, 1 / 2]))
 
     @property
-    def geometry(self) -> shapely.Polygon:  # numpydoc ignore=RT01
-        """shapely.Polygon: A shapely geometry for the fault (projected onto the surface)."""
+    def geometry(self) -> shapely.Polygon | shapely.LineString:  # numpydoc ignore=RT01
+        """shapely.Polygon or LineString: A shapely geometry for the fault (projected onto the surface).
+
+        Geometry will be LineString if `dip = 90`.
+        """
         return shapely.normalize(
             shapely.union_all([plane.geometry for plane in self.planes])
         )

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -400,8 +400,10 @@ class Plane:
         return np.degrees(np.arcsin(np.abs(self.bottom_m - self.top_m) / self.width_m))
 
     @property
-    def geometry(self) -> shapely.Polygon:  # numpydoc ignore=RT01
+    def geometry(self) -> shapely.Polygon | shapely.LineString:  # numpydoc ignore=RT01
         """shapely.Polygon: A shapely geometry for the plane (projected onto the surface)."""
+        if self.dip == 90:
+            return shapely.LineString(self.bounds[:2])
         return shapely.Polygon(self.bounds)
 
     @classmethod

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -56,10 +56,11 @@ import numpy as np
 import pandas as pd
 import scipy as sp
 import shapely
-
 from qcore import coordinates
+
 from source_modelling import srf_reader
 from source_modelling.sources import Plane
+
 
 PLANE_COUNT_RE = r"PLANE (\d+)"
 POINT_COUNT_RE = r"POINTS (\d+)"
@@ -490,6 +491,7 @@ def read_srf(srf_ffp: Path) -> SrfFile:
                 "slip1",
                 "slip2",
                 "slip3",
+                "rise",
             ],
         )
 

--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -56,11 +56,10 @@ import numpy as np
 import pandas as pd
 import scipy as sp
 import shapely
-from qcore import coordinates
 
+from qcore import coordinates
 from source_modelling import srf_reader
 from source_modelling.sources import Plane
-
 
 PLANE_COUNT_RE = r"PLANE (\d+)"
 POINT_COUNT_RE = r"POINTS (\d+)"

--- a/source_modelling/srf_reader.pyx
+++ b/source_modelling/srf_reader.pyx
@@ -147,6 +147,7 @@ cdef void read_srf_points_loop(FILE* srf_file, int point_count, DTYPE_t[:, :] me
     cdef int nt3
     cdef int i
     cdef int start_column_index
+    cdef int max_nt
     for i in range(point_count):
         fscanf(srf_file, "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %d %lf %d %lf %d",
                &metadata[i, 0],  # lat
@@ -165,6 +166,12 @@ cdef void read_srf_points_loop(FILE* srf_file, int point_count, DTYPE_t[:, :] me
                &metadata[i, 11], # slip3
                &nt3              # number of slipt3 values for this point
                )
+        max_nt = nt1
+        if nt2 > max_nt:
+           max_nt = nt2
+        if nt3 > max_nt:
+           max_nt = nt3
+        metadata[i, 12] = max_nt * metadata[i, 7] # rise time
         start_column_index = <int> (metadata[i, 6] / metadata[i, 7])
         read_slipt_values(srf_file, start_column_index, nt1, slipt1s)
         read_slipt_values(srf_file, start_column_index, nt2, slipt2s)
@@ -241,7 +248,7 @@ def read_srf_points(
         The sparse matrix of slip values in the third component for each
         point.
     """
-    cdef np.ndarray[DTYPE_t, ndim=2] metadata = pnp.zeros([point_count, 12], dtype=DTYPE)
+    cdef np.ndarray[DTYPE_t, ndim=2] metadata = pnp.zeros([point_count, 13], dtype=DTYPE)
     cdef DTYPE_t[:, :] metadata_view = metadata
     
     cdef sparse_matrix slip1ts

--- a/tests/test_slip.py
+++ b/tests/test_slip.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import scipy as sp
 from hypothesis import given
 from hypothesis import strategies as st
 

--- a/tests/test_slip.py
+++ b/tests/test_slip.py
@@ -15,7 +15,7 @@ def test_box_car_slip(t0: float, offset: float, total_slip: float):
     For the box car slip function we must have:
 
     1. Slip is always non-negative,
-    3. Slip function integrates to total slip over the interval [t0, t1].
+    2. Slip function integrates to total slip over the interval [t0, t1].
     """
     t1 = t0 + offset
     t = np.linspace(t0, t1, num=100)

--- a/tests/test_slip.py
+++ b/tests/test_slip.py
@@ -7,37 +7,37 @@ from hypothesis import strategies as st
 from source_modelling import slip
 
 
-@given(t0=st.floats(0.1, 100), dt=st.floats(1e-6, 100), total_slip=st.floats(1, 1000))
-def test_box_car_slip(t0: float, dt: float, total_slip: float):
+@given(
+    t0=st.floats(0.1, 100), offset=st.floats(1e-6, 100), total_slip=st.floats(1, 1000)
+)
+def test_box_car_slip(t0: float, offset: float, total_slip: float):
     """Check that the box car slip function is a well-behaved slip function.
 
     For the box car slip function we must have:
 
     1. Slip is always non-negative,
-    2. Slip is zero at t0 and t1,
     3. Slip function integrates to total slip over the interval [t0, t1].
     """
-    t1 = t0 + dt
-    t = np.linspace(t0, t1, num=20)
+    t1 = t0 + offset
+    t = np.linspace(t0, t1, num=100)
+    dt = t[1] - t[0]
     slip_function = slip.box_car_slip(t, t0, t1, total_slip)
 
     # Slip should be non-negative
     assert np.all(slip_function >= 0)
-    # Total slip integrated should be close to the total slip given.
-    # Using scipy quad because numpy trapz is not good enough
-    total_slip_from_function, _ = sp.integrate.quad(
-        lambda t: slip.box_car_slip(t, t0, t1, total_slip), t0, t1
-    )
+    total_slip_from_function = np.trapz(slip_function, dx=dt)
     assert np.allclose(total_slip_from_function, total_slip)
 
 
 @given(
     t0=st.floats(0.1, 100),
     peak_position=st.floats(0.1, 0.9),
-    dt=st.floats(1e-6, 100),
+    offset=st.floats(1e-6, 100),
     total_slip=st.floats(1, 1000),
 )
-def test_triangular_slip(t0: float, peak_position: float, dt: float, total_slip: float):
+def test_triangular_slip(
+    t0: float, peak_position: float, offset: float, total_slip: float
+):
     """Check that the triangular slip function is a well-behaved slip function.
 
     For the triangular slip function we must have:
@@ -46,29 +46,26 @@ def test_triangular_slip(t0: float, peak_position: float, dt: float, total_slip:
     2. Slip is zero at t0 and t1,
     3. Slip function integrates to total slip over the interval [t0, t1].
     """
-    t1 = t0 + dt
-    peak = t0 + peak_position * dt
-    t = np.linspace(t0, t1, num=20)
+    t1 = t0 + offset
+    peak = t0 + peak_position * offset
+    t = np.linspace(t0, t1, num=200)
+    dt = t[1] - t[0]
     slip_function = slip.triangular_slip(t, t0, t1, peak, total_slip)
 
     # Slip should be non-negative and zero at boundaries
     assert np.all(slip_function >= 0)
     assert slip_function[0] == pytest.approx(0)
     assert slip_function[-1] == pytest.approx(0)
-    # Total slip integrated should be close to the total slip given.
-    # Using scipy quad because numpy trapz is not good enough
-    total_slip_from_function, _ = sp.integrate.quad(
-        lambda t: slip.triangular_slip(t, t0, t1, peak, total_slip), t0, t1
-    )
-    assert np.allclose(total_slip_from_function, total_slip)
+    total_slip_from_function = np.trapz(slip_function, dx=dt)
+    assert total_slip_from_function == pytest.approx(total_slip, rel=1e-4)
 
 
 @given(
     t0=st.floats(0.1, 100),
-    dt=st.floats(1e-6, 100),
+    offset=st.floats(1e-6, 100),
     total_slip=st.floats(1, 1000),
 )
-def test_isoceles_triangular_slip(t0: float, dt: float, total_slip: float):
+def test_isoceles_triangular_slip(t0: float, offset: float, total_slip: float):
     """Check that the isoceles triangular slip function is a well-behaved slip function.
 
     For the isoceles slip function we must have:
@@ -77,28 +74,25 @@ def test_isoceles_triangular_slip(t0: float, dt: float, total_slip: float):
     2. Slip is zero at t0 and t1,
     3. Slip function integrates to total slip over the interval [t0, t1].
     """
-    t1 = t0 + dt
-    t = np.linspace(t0, t1, num=20)
+    t1 = t0 + offset
+    t = np.linspace(t0, t1, num=200)
+    dt = t[1] - t[0]
     slip_function = slip.isoceles_triangular_slip(t, t0, t1, total_slip)
 
     # Slip should be non-negative and zero at boundaries
     assert np.all(slip_function >= 0)
     assert slip_function[0] == pytest.approx(0)
     assert slip_function[-1] == pytest.approx(0)
-    # Total slip integrated should be close to the total slip given.
-    # Using scipy quad because numpy trapz is not good enough
-    total_slip_from_function, _ = sp.integrate.quad(
-        lambda t: slip.isoceles_triangular_slip(t, t0, t1, total_slip), t0, t1
-    )
-    assert np.allclose(total_slip_from_function, total_slip)
+    total_slip_from_function = np.trapz(slip_function, dx=dt)
+    assert total_slip_from_function == pytest.approx(total_slip, rel=1e-4)
 
 
 @given(
     t0=st.floats(0.1, 100),
-    dt=st.floats(1e-6, 100),
+    offset=st.floats(1e-6, 100),
     total_slip=st.floats(1, 1000),
 )
-def test_cosine_slip(t0: float, dt: float, total_slip: float):
+def test_cosine_slip(t0: float, offset: float, total_slip: float):
     """Check that the cosine slip function is a well-behaved slip function.
 
     For the cosine slip function we must have:
@@ -107,8 +101,9 @@ def test_cosine_slip(t0: float, dt: float, total_slip: float):
     2. Slip is zero at t0 and t1,
     3. Slip function integrates to total slip over the interval [t0, t1].
     """
-    t1 = t0 + dt
-    t = np.linspace(t0, t1, num=20)
+    t1 = t0 + offset
+    t = np.linspace(t0, t1, num=200)
+    dt = t[1] - t[0]
     slip_function = slip.cosine_slip(t, t0, t1, total_slip)
 
     # Slip should be non-negative and zero at boundaries
@@ -117,10 +112,5 @@ def test_cosine_slip(t0: float, dt: float, total_slip: float):
     # np.cos approximation errors.
     assert slip_function[0] == pytest.approx(0, abs=1e-6)
     assert slip_function[-1] == pytest.approx(0, abs=1e-6)
-    # Total slip integrated should be close to the total slip given.
-    # Using scipy quad because numpy trapz is not good enough
-    total_slip_from_function, _ = sp.integrate.quad(
-        lambda t: slip.cosine_slip(t, t0, t1, total_slip), t0, t1
-    )
-    # Need to be a bit more lenient for the approximation here.
-    assert np.allclose(total_slip_from_function, total_slip, atol=1e-6)
+    total_slip_from_function = np.trapz(slip_function, dx=dt)
+    assert total_slip_from_function == pytest.approx(total_slip, rel=1e-4)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -402,9 +402,14 @@ def test_plane_from_trace(data: tuple):
     assert pytest.approx(plane.projected_width, abs=1e-3) == width * np.cos(
         np.radians(dip)
     )
-    assert shapely.get_coordinates(plane.geometry, include_z=True)[
-        :-1
-    ] == pytest.approx(plane.bounds)
+    if plane.dip == 90:
+        assert shapely.get_coordinates(plane.geometry, include_z=True) == pytest.approx(
+            plane.bounds[:2]
+        )
+    else:
+        assert shapely.get_coordinates(plane.geometry, include_z=True)[
+            :-1
+        ] == pytest.approx(plane.bounds)
 
     # Generate plane using dip_dir
     plane = Plane.from_nztm_trace(

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -425,9 +425,14 @@ def test_plane_from_trace(data: tuple):
         plane.projected_width / np.cos(np.radians(plane.dip)), abs=1e-6
     )
     assert pytest.approx(plane.length_m, abs=1e-3) == length
-    assert shapely.get_coordinates(plane.geometry, include_z=True)[
-        :-1
-    ] == pytest.approx(plane.bounds)
+    if plane.dip == 90:
+        assert shapely.get_coordinates(plane.geometry, include_z=True) == pytest.approx(
+            plane.bounds[:2]
+        )
+    else:
+        assert shapely.get_coordinates(plane.geometry, include_z=True)[
+            :-1
+        ] == pytest.approx(plane.bounds)
 
 
 def test_invalid_trace_points():

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -249,9 +249,15 @@ def test_plane_construction(
     assert np.isclose(
         plane.projected_width, plane.width * np.cos(np.radians(plane.dip)), atol=1e-6
     )
-    assert np.allclose(
-        shapely.get_coordinates(plane.geometry, include_z=True)[:-1], plane.bounds
-    )
+    if plane.dip == 90:
+        assert shapely.get_coordinates(plane.geometry, include_z=True) == pytest.approx(
+            plane.bounds[:2]
+        )
+    else:
+        assert shapely.get_coordinates(plane.geometry, include_z=True)[
+            :-1
+        ] == pytest.approx(plane.bounds)
+
     assert np.isclose(plane.strike_nztm, strike, atol=1e-6)
 
     # Check that the plane bounds orientation makes sense.

--- a/tests/test_srf.py
+++ b/tests/test_srf.py
@@ -52,22 +52,24 @@ def test_christchurch_srf():
     # regression test for future parsing changes.
     assert christchurch_srf.nt == 361
 
-    assert christchurch_srf.points.iloc[0].to_dict() == {
-        "lon": 172.6127,
-        "lat": -43.5821,
-        "dep": 0.6767,
-        "stk": 59,
-        "dip": 69,
-        "area": 1.0e08,
-        "tinit": 5.7029,
-        "dt": 2.5e-02,
-        "rake": 102,
-        "slip1": 17.49,
-        "slip2": 0.0,
-        "slip3": 0.0,
-        "slip": 17.49,
-        'rise': 0.3
-    }
+    assert christchurch_srf.points.iloc[0].to_dict() == pytest.approx(
+        {
+            "lon": 172.6127,
+            "lat": -43.5821,
+            "dep": 0.6767,
+            "stk": 59,
+            "dip": 69,
+            "area": 1.0e08,
+            "tinit": 5.7029,
+            "dt": 2.5e-02,
+            "rake": 102,
+            "slip1": 17.49,
+            "slip2": 0.0,
+            "slip3": 0.0,
+            "slip": 17.49,
+            "rise": 0.3,
+        }
+    )
     tinit_index = int(christchurch_srf.points["tinit"].iloc[0] // christchurch_srf.dt)
     # have to manually slice because the sparse arrays do not support slicing
     slip_window = [

--- a/tests/test_srf.py
+++ b/tests/test_srf.py
@@ -66,6 +66,7 @@ def test_christchurch_srf():
         "slip2": 0.0,
         "slip3": 0.0,
         "slip": 17.49,
+        'rise': 0.3
     }
     tinit_index = int(christchurch_srf.points["tinit"].iloc[0] // christchurch_srf.dt)
     # have to manually slice because the sparse arrays do not support slicing


### PR DESCRIPTION
This PR adds SRF parsing support to extract the rise time. This is required for new source modelling plots, it's also just nice to have. It also catches an edge-case for the `.geometry` property to return a `shapely.LineString` instead of a `shapely.Polygon` when `dip = 90`.