### PR TITLE
Use sp.integrate.trapezoid instead of np.trapezoid

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,3 +1,0 @@
-name: Coverage
-on: [pull_request]
-jobs:

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -76,7 +76,7 @@ def moment_over_time_from_moment_rate(moment_rate_df: pd.DataFrame) -> pd.DataFr
         A dataframe the same index and a 'moment' column with cumulative rupture moment.
     """
     integrate_f = np.vectorize(
-        lambda i: np.trapezoid(
+        lambda i: sp.integrate.trapezoid(
             moment_rate_df["moment_rate"].iloc[: i + 1].to_numpy(),
             moment_rate_df.index.values[: i + 1],
         )

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -31,7 +31,7 @@ def test_moment_rate_from_slip_properties(slip_function: np.ndarray, dt: float):
     )
     assert (moment_rate["moment_rate"] >= 0).all()
     assert len(moment_rate) == nt
-    avg_displacement = np.mean(np.trapezoid(slip_function, dx=dt, axis=1)) / 1e6
+    avg_displacement = np.mean(sp.integrate.trapezoid(slip_function, dx=dt, axis=1)) / 1e6
     cumulative_moment = moment.moment_over_time_from_moment_rate(moment_rate)
     assert moment.MU * np.sum(patch_areas) * avg_displacement == pytest.approx(
         cumulative_moment["moment"].iloc[-1]

--- a/tests/test_slip.py
+++ b/tests/test_slip.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import scipy as sp
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -24,7 +25,7 @@ def test_box_car_slip(t0: float, offset: float, total_slip: float):
 
     # Slip should be non-negative
     assert np.all(slip_function >= 0)
-    total_slip_from_function = np.trapezoid(slip_function, dx=dt)
+    total_slip_from_function = sp.integrate.trapezoid(slip_function, dx=dt)
     assert np.allclose(total_slip_from_function, total_slip)
 
 
@@ -55,7 +56,7 @@ def test_triangular_slip(
     assert np.all(slip_function >= 0)
     assert slip_function[0] == pytest.approx(0)
     assert slip_function[-1] == pytest.approx(0)
-    total_slip_from_function = np.trapezoid(slip_function, dx=dt)
+    total_slip_from_function = sp.integrate.trapezoid(slip_function, dx=dt)
     assert total_slip_from_function == pytest.approx(total_slip, rel=1e-4)
 
 
@@ -82,7 +83,7 @@ def test_isoceles_triangular_slip(t0: float, offset: float, total_slip: float):
     assert np.all(slip_function >= 0)
     assert slip_function[0] == pytest.approx(0)
     assert slip_function[-1] == pytest.approx(0)
-    total_slip_from_function = np.trapezoid(slip_function, dx=dt)
+    total_slip_from_function = sp.integrate.trapezoid(slip_function, dx=dt)
     assert total_slip_from_function == pytest.approx(total_slip, rel=1e-4)
 
 
@@ -111,5 +112,5 @@ def test_cosine_slip(t0: float, offset: float, total_slip: float):
     # np.cos approximation errors.
     assert slip_function[0] == pytest.approx(0, abs=1e-6)
     assert slip_function[-1] == pytest.approx(0, abs=1e-6)
-    total_slip_from_function = np.trapezoid(slip_function, dx=dt)
+    total_slip_from_function = sp.integrate.trapezoid(slip_function, dx=dt)
     assert total_slip_from_function == pytest.approx(total_slip, rel=1e-4)


### PR DESCRIPTION
In migrating to numpy 2, we replaced `np.trapz` with `np.trapezoid` because `np.trapz` was removed from numpy version 2. However, `np.trapezoid` was new to numpy 2, which means the code no longer works with any numpy version *except* `2.x`. Obviously, this is not desirable and hence this PR uses `sp.integrate.trapezoid`, which means that the code works with all versions of numpy.