### PR TITLE
Add a source modelling magnitude scaling module

### DIFF
--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -1,0 +1,635 @@
+import functools
+from enum import Enum, StrEnum, auto
+from typing import cast
+
+import numpy as np
+import scipy as sp
+
+
+class RakeType(Enum):
+    """Enumeration of rake types."""
+
+    NORMAL = auto()
+    REVERSE = auto()
+    STRIKE_SLIP = auto()
+    REVERSE_OBLIQUE = auto()
+    NORMAL_OBLIQUE = auto()
+    UNDEFINED = auto()
+
+
+class ScalingRelation(StrEnum):
+    """Enumeration of scaling relations."""
+
+    LEONARD2014 = auto()
+    CONTRERAS_INTERFACE2017 = auto()
+    CONTRERAS_SLAB2020 = auto()
+
+
+def rake_type(rake: float) -> RakeType:
+    """Determine the rake type of a fault given its rake.
+
+    Parameters
+    ----------
+    rake : float
+        Rake of the fault.
+
+    Returns
+    -------
+    RakeType
+        Type of rake of the fault.
+    """
+    if -30 <= rake <= 30 or 150 <= rake <= 210:
+        return RakeType.STRIKE_SLIP
+    elif 60 <= rake <= 120:
+        return RakeType.REVERSE
+    elif -120 <= rake <= -60:
+        return RakeType.NORMAL
+    elif -150 < rake < -120 or -60 < rake < -30:
+        return RakeType.NORMAL_OBLIQUE
+    elif 30 < rake < 60 or 120 < rake < 150:
+        return RakeType.REVERSE_OBLIQUE
+
+    return RakeType.UNDEFINED
+
+
+def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) -> float:
+    """Convert area to magnitude using the leonard scaling relationship [0]_.
+
+    Parameters
+    ----------
+    area : float
+        Area of the fault (km^2).
+    rake : float
+        Rake of the fault (degrees).
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the *best-fit* values. Default is False.
+
+    Returns
+    -------
+    float
+        Moment magnitude of the fault.
+
+    Notes
+    -----
+    If the rake is not strike-slip, the uncertainties are assymetric.
+    Hence, setting `random = False` is not equivalent to using the
+    mean value for the parameters for all faults. Paremeter values are
+    found in Table 4 of [0]_.
+
+    References
+    ----------
+    .. [0] Leonard, Mark. "Self‐consistent earthquake fault‐scaling
+           relations: Update and extension to stable continental strike‐slip
+           faults." Bulletin of the Seismological Society of America 104.6
+           (2014): 2953-2965.
+    """
+
+    if rake_type(rake) == RakeType.STRIKE_SLIP:
+        return np.log10(area) + (
+            sp.stats.norm.rvs(loc=3.99, scale=0.26) if random else 3.99
+        )
+
+    # Leonard quotes assymetric uncertainties for the other rake types.
+    return np.log10(area) + (sp.stats.norm.rvs(loc=4.03, scale=0.3) if random else 4.0)
+
+
+def leonard_magnitude_to_area(
+    magnitude: float, rake: float, random: bool = False
+) -> float:
+    """Convert magnitude to area using the Leonard scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+        Moment magnitude of the fault.
+    rake : float
+        Rake of the fault (degrees).
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the *best-fit* values. Default is False.
+
+    Returns
+    -------
+    float
+        Area of the fault. (km^2)
+
+    Notes
+    -----
+    If the rake is not strike-slip, the uncertainties are assymetric.
+    Hence, setting `random = False` is not equivalent to using the
+    mean values.
+
+    References
+    ----------
+    .. [0] Leonard, Mark. "Self‐consistent earthquake fault‐scaling
+           relations: Update and extension to stable continental strike‐slip
+           faults." Bulletin of the Seismological Society of America 104.6
+           (2014): 2953-2965.
+    """
+    if rake_type(rake) == RakeType.STRIKE_SLIP:
+        return 10 ** (
+            magnitude - (sp.stats.norm.rvs(loc=3.99, scale=0.26) if random else 3.99)
+        )
+
+    # Leonard quotes assymetric uncertainties for the other rake types.
+    return 10 ** (
+        magnitude - (sp.stats.norm.rvs(loc=4.03, scale=0.3) if random else 4.0)
+    )
+
+
+def leonard_magnitude_to_length(
+    magnitude: float,
+    rake: float,
+    random: bool = False,
+) -> float:
+    """Convert magnitude to length using the Leonard scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+            Moment magnitude of the fault.
+    rake : float
+            Rake of the fault (degrees).
+    random : bool, optional
+            If True, sample parameters according to uncertainties in the
+            paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    float
+            Length of the fault. (km)
+    """
+    a_strike_slip_small = sp.stats.norm.rvs(loc=4.16, scale=0.39) if random else 4.17
+    b_strike_slip_small = 1.667
+    a_strike_slip_large = 5.27
+    b_strike_slip_large = 1.0
+    length: float
+    if rake_type(rake) == RakeType.STRIKE_SLIP:
+        length = 10 ** ((magnitude - a_strike_slip_small) / b_strike_slip_small)
+
+        if length > 45.0:
+            length = 10 ** ((magnitude - a_strike_slip_large) / b_strike_slip_large)
+    else:
+        a_dip_slip_small = 4
+        b_dip_slip_small = 2
+        a_dip_slip_large = 4.24
+        b_dip_slip_large = 1.667
+
+        length = 10 ** ((magnitude - a_dip_slip_small) / b_dip_slip_small)
+        if length > 5.4:
+            length = 10 ** ((magnitude - a_dip_slip_large) / b_dip_slip_large)
+
+    return length
+
+
+def leonard_magnitude_to_width(
+    magnitude: float,
+    rake: float,
+    random: bool = False,
+) -> float:
+    """Convert magnitude to width using the Leonard scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+            Moment magnitude of the fault.
+    rake : float
+            Rake of the fault (degrees).
+    random : bool, optional
+            If True, sample parameters according to uncertainties in the
+            paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    float
+            Width of the fault. (km)
+    """
+    a_strike_slip_small = sp.stats.norm.rvs(loc=3.885, scale=0.065) if random else 3.88
+    b_strike_slip_small = 2.5
+    width: float
+    if rake_type(rake) == RakeType.STRIKE_SLIP:
+        width = 10 ** ((magnitude - a_strike_slip_small) / b_strike_slip_small)
+        if width > 19.0 or width < 3.4:
+            raise ValueError("Width out of range for Leonard model.")
+    else:
+        a_dip_slip_small = sp.stats.norm.rvs(loc=3.67, scale=0.06) if random else 3.63
+        b_dip_slip_small = 2.5
+        width = 10 ** ((magnitude - a_dip_slip_small) / b_dip_slip_small)
+        if width <= 5.4:
+            raise ValueError("Width out of range for Leonard model.")
+
+    return width
+
+
+def leonard_magnitude_to_length_width(
+    magnitude: float,
+    rake: float,
+    random: bool = False,
+) -> tuple[float, float]:
+    """Convert magnitude to length and width using the Leonard scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+        Moment magnitude of the fault.
+    rake : float
+        Rake of the fault (degrees).
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    tuple[float, float]
+        Length and width of the fault.
+    """
+    area = leonard_magnitude_to_area(magnitude, rake, random)
+    length = leonard_magnitude_to_length(magnitude, rake, random)
+    width = leonard_magnitude_to_width(magnitude, rake, random)
+    aspect_ratio = max(length / width, 1)
+    width = np.sqrt(area / aspect_ratio)
+    length = width * aspect_ratio
+    return length, width
+
+
+def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> float:
+    """Convert area to magnitude using the Contreras scaling relationship [0]_.
+
+    Parameters
+    ----------
+    area : float
+        Area of the fault (km^2).
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    float
+        Moment magnitude of the fault.
+
+    Raises
+    ------
+    ValueError
+        If the area is less than the minimum area of 137.76 km^2.
+
+    Notes
+    -----
+    This scaling relationship for *interface* events. For slab events,
+    use the original Strasser scaling relationship [1]_.
+
+    References
+    ----------
+    .. [0] Contreras, Victor, et al. "NGA-Sub source and path database." Earthquake Spectra 38.2 (2022): 799-840.
+    .. [1] Strasser, Fleur O., M. C. Arango, and Julian J. Bommer.
+           "Scaling of the source dimensions of interface and intraslab
+           subduction-zone earthquakes with moment magnitude." Seismological
+           Research Letters 81.6 (2010): 941-950.
+    """
+    if area < 137.76:
+        raise ValueError(
+            "Area out of range for Contreras model, minimum area is 137.76 km^2"
+        )
+    sigma_a = 0 if random else sp.stats.norm.rvs(loc=0, scale=0.73)
+    a_1 = -8.890
+    a_2 = np.log(10)
+    return 1 / a_2 * (np.log(area) - a_1 - sigma_a)
+
+
+def contreras_interface_magnitude_to_area(
+    magnitude: float, random: bool = False
+) -> float:
+    """Convert magnitude to area using the Contreras scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+        Moment magnitude of the fault.
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    float
+        Area of the fault. (km^2)
+
+    Raises
+    ------
+    ValueError
+        If the magnitude is less than the minimum magnitude of 6.
+
+    Notes
+    -----
+    This relationship is for *interface* events. For slab events, use the
+    Strasser scaling relationship [1]_.
+
+    References
+    ----------
+    .. [0] Contreras, Victor, et al. "NGA-Sub source and path database." Earthquake Spectra 38.2 (2022): 799-840.
+    .. [1] Strasser, Fleur O., M. C. Arango, and Julian J. Bommer.
+           "Scaling of the source dimensions of interface and intraslab
+           subduction-zone earthquakes with moment magnitude." Seismological
+           Research Letters 81.6 (2010): 941-950.
+    """
+    if magnitude < 6:
+        raise ValueError(
+            "Magnitude out of range for Contreras model, minimum magnitude is 6"
+        )
+    sigma_a = 0 if random else sp.stats.norm.rvs(loc=0, scale=0.73)
+    a_1 = -8.890
+    a_2 = np.log(10)
+    return np.exp(a_1 + a_2 * magnitude + sigma_a)
+
+
+def contreras_interface_magnitude_to_aspect_ratio(
+    magnitude: float, random: bool = False
+) -> float:
+    """Convert magnitude to aspect ratio (L/W) using the Contreras scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+        Moment magnitude of the fault.
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    float
+        Aspect ratio of the fault.
+
+    Raises
+    ------
+    ValueError
+        If the magnitude is less than the minimum magnitude of 6.
+
+    References
+    ----------
+    .. [0] Contreras, Victor, et al. "NGA-Sub source and path database." Earthquake Spectra 38.2 (2022): 799-840.
+    """
+    if magnitude < 6:
+        raise ValueError(
+            "Magnitude out of range for Contreras model, minimum magnitude is 6"
+        )
+    a_3 = 0.6248
+    M_1 = 7.25
+    sigma_1 = 0.32
+    sigma_2 = 0.47
+    if magnitude < M_1:
+        return np.exp(sp.stats.norm.rvs(loc=0, scale=sigma_1) if random else 0)
+
+    return np.exp(
+        a_3 * (magnitude - M_1)
+        + (sp.stats.norm.rvs(loc=0, scale=sigma_2) if random else 0)
+    )
+
+
+def contreras_interface_magnitude_to_length_width(
+    magnitude: float, random: bool = False
+) -> tuple[float, float]:
+    """Convert magnitude to length and width using the Contreras scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+            Moment magnitude of the fault.
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    tuple[float, float]
+            Length and width of the fault.
+    """
+    area = contreras_interface_magnitude_to_area(magnitude, random)
+    aspect_ratio = contreras_interface_magnitude_to_aspect_ratio(magnitude, random)
+    width = np.sqrt(area / aspect_ratio)
+    length = width * aspect_ratio
+    return length, width
+
+
+def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> float:
+    """Convert area to magnitude using the Strasser scaling relationship [0]_.
+
+    Parameters
+    ----------
+    area : float
+        Area of the fault (km^2).
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    float
+        Moment magnitude of the fault.
+
+    Raises
+    ------
+    ValueError
+        If the area is less than the minimum area of 137.76 km^2.
+
+    References
+    ----------
+    .. [0] Strasser, Fleur O., M. C. Arango, and Julian J. Bommer.
+           "Scaling of the source dimensions of interface and intraslab
+           subduction-zone earthquakes with moment magnitude." Seismological
+           Research Letters 81.6 (2010): 941-950.
+    """
+    a = 4.054
+    b = 0.981
+    sigma_a = sp.stats.norm(loc=0, scale=0.288) if random else 0
+    sigma_b = sp.stats.norm(loc=0, scale=0.093) if random else 0
+
+    return a + sigma_a + (b + sigma_b) * np.log10(area)
+
+
+def strasser_slab_magnitude_to_area(magnitude: float, random: bool = False) -> float:
+    """Convert magnitude to area using the Strasser scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+        Moment magnitude of the fault.
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    float
+        Area of the fault. (km^2)
+
+    Raises
+    ------
+    ValueError
+        If the magnitude is less than the minimum magnitude of 6.
+
+    References
+    ----------
+    .. [0] Strasser, Fleur O., M. C. Arango, and Julian J. Bommer.
+           "Scaling of the source dimensions of interface and intraslab
+           subduction-zone earthquakes with moment magnitude." Seismological
+           Research Letters 81.6 (2010): 941-950.
+    """
+    a = -3.225
+    sigma_a = sp.stats.norm(loc=0, scale=0.598) if random else 0
+    b = 0.890
+    sigma_b = sp.stats.norm(loc=0, scale=0.085) if random else 0
+    return 10 ** (a + sigma_a + (b + sigma_b) * magnitude)
+
+
+def contreras_slab_magnitude_to_aspect_ratio(
+    magnitude: float, random: bool = False
+) -> float:
+    """Convert magnitude to aspect ratio (L/W) using the Contreras scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+        Moment magnitude of the fault.
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    float
+        Aspect ratio of the fault.
+
+    Raises
+    ------
+    ValueError
+        If the magnitude is less than the minimum magnitude of 5.
+
+    References
+    ----------
+    .. [0] Bozorgnia, Y., & Stewart, J.P. (2020). Data Resources for
+           NGA-Subduction Project (Report No. 2020/02). Pacific Earthquake
+           Engineering Research Center (PEER).
+           https://doi.org/10.55461/RDWC6463
+    """
+    if magnitude < 5:
+        raise ValueError(
+            "Magnitude out of range for Contreras model, minimum magnitude is 6"
+        )
+    a_3 = 0.216
+    M_1 = 6.5
+    sigma_1 = 0.24
+    sigma_2 = 0.38
+    if magnitude < M_1:
+        return np.exp(sp.stats.norm.rvs(loc=0, scale=sigma_1) if random else 0)
+
+    return np.exp(
+        a_3 * (magnitude - M_1)
+        + (sp.stats.norm.rvs(loc=0, scale=sigma_2) if random else 0)
+    )
+
+
+def contreras_slab_magnitude_to_length_width(
+    magnitude: float, random: bool = False
+) -> tuple[float, float]:
+    """Convert magnitude to length and width using the Contreras scaling relationship [0]_.
+
+    Parameters
+    ----------
+    magnitude : float
+            Moment magnitude of the fault.
+    random : bool, optional
+            If True, sample parameters according to uncertainties in the
+            paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    tuple[float, float]
+            Length and width of the fault.
+    """
+    area = strasser_slab_magnitude_to_area(magnitude, random)
+    aspect_ratio = contreras_slab_magnitude_to_aspect_ratio(magnitude, random)
+    width = np.sqrt(area / aspect_ratio)
+    length = width * aspect_ratio
+    return length, width
+
+
+def magnitude_to_length_width(
+    scaling_relation: ScalingRelation,
+    magnitude: float,
+    rake: float | None = None,
+    random: bool = True,
+) -> tuple[float, float]:
+    """Convert magnitude to length and width using a scaling relationship.
+
+    Parameters
+    ----------
+    scaling_relation : ScalingRelation
+        Scaling relation to use.
+    magnitude : float
+        Moment magnitude of the fault.
+    rake : float, optional
+        Rake of the fault (degrees). Required for Leonard scaling.
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    tuple[float, float]
+            Length and width of the fault estimated by the scaling relation.
+    """
+    if scaling_relation == ScalingRelation.LEONARD2014 and rake is None:
+        raise ValueError("Rake must be specified for Leonard scaling.")
+    scaling_relations_map = {
+        ScalingRelation.LEONARD2014: functools.partial(
+            leonard_magnitude_to_length_width, rake=rake, random=random
+        ),
+        ScalingRelation.CONTRERAS_INTERFACE2017: functools.partial(
+            contreras_interface_magnitude_to_length_width, random=random
+        ),
+        ScalingRelation.CONTRERAS_SLAB2020: functools.partial(
+            contreras_slab_magnitude_to_length_width, random=random
+        ),
+    }
+    return scaling_relations_map[scaling_relation](magnitude)
+
+
+def area_to_magnitude(
+    scaling_relation: ScalingRelation,
+    area: float,
+    rake: float | None = None,
+    random: bool = True,
+) -> float:
+    """Convert area to magnitude using a scaling relationship.
+
+    Parameters
+    ----------
+    scaling_relation : ScalingRelation
+        Scaling relation to use.
+    area : float
+        Area of the fault (km^2).
+    rake : float, optional
+        Rake of the fault (degrees). Required for Leonard scaling.
+    random : bool, optional
+        If True, sample parameters according to uncertainties in the
+        paper, otherwise use the mean values. Default is False.
+
+    Returns
+    -------
+    float
+        Moment magnitude of the fault estimated by the scaling relation.
+    """
+    scaling_relations_map = {
+        ScalingRelation.LEONARD2014: functools.partial(
+            leonard_area_to_magnitude, rake=rake, random=random
+        ),
+        ScalingRelation.CONTRERAS_INTERFACE2017: functools.partial(
+            contreras_interface_area_to_magnitude, random=random
+        ),
+        ScalingRelation.CONTRERAS_SLAB2020: functools.partial(
+            strasser_slab_area_to_magnitude, random=random
+        ),
+    }
+    return scaling_relations_map[scaling_relation](area)

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -2,7 +2,6 @@
 
 import functools
 from enum import Enum, StrEnum, auto
-from typing import cast
 
 import numpy as np
 import scipy as sp
@@ -408,14 +407,14 @@ def contreras_interface_magnitude_to_aspect_ratio(
             "Magnitude out of range for Contreras model, minimum magnitude is 6"
         )
     a_3 = 0.6248
-    M_1 = 7.25
+    m_1 = 7.25
     sigma_1 = 0.32
     sigma_2 = 0.47
-    if magnitude < M_1:
+    if magnitude < m_1:
         return np.exp(sp.stats.norm(loc=0, scale=sigma_1).rvs() if random else 0)
 
     return np.exp(
-        a_3 * (magnitude - M_1)
+        a_3 * (magnitude - m_1)
         + (sp.stats.norm(loc=0, scale=sigma_2).rvs() if random else 0)
     )
 
@@ -549,14 +548,14 @@ def contreras_slab_magnitude_to_aspect_ratio(
             "Magnitude out of range for Contreras model, minimum magnitude is 6"
         )
     a_3 = 0.216
-    M_1 = 6.5
+    m_1 = 6.5
     sigma_1 = 0.24
     sigma_2 = 0.38
-    if magnitude < M_1:
+    if magnitude < m_1:
         return np.exp(sp.stats.norm(loc=0, scale=sigma_1).rvs() if random else 0)
 
     return np.exp(
-        a_3 * (magnitude - M_1)
+        a_3 * (magnitude - m_1)
         + (sp.stats.norm(loc=0, scale=sigma_2).rvs() if random else 0)
     )
 

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -1,3 +1,5 @@
+"""Magnitude scaling relationships for fault dimensions."""
+
 import functools
 from enum import Enum, StrEnum, auto
 from typing import cast
@@ -265,7 +267,20 @@ def leonard_magnitude_to_length_width(
 def area_aspect_ratio_to_length_width(
     area: float, aspect_ratio: float
 ) -> tuple[float, float]:
-    """Convert area and aspect ratio to length and width."""
+    """Convert area and aspect ratio to length and width.
+
+    Parameters
+    ----------
+    area : float
+        Area of the fault (km^2).
+    aspect_ratio : float
+        Aspect ratio of the fault (length / width).
+
+    Returns
+    -------
+    tuple[float, float]
+        Length and width of the fault.
+    """
     width = np.sqrt(area / aspect_ratio)
     length = area / width
     return length, width

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -169,6 +169,14 @@ def leonard_magnitude_to_length(
     -------
     float
             Length of the fault. (km)
+
+    References
+    ----------
+    .. [0] Leonard, Mark. "Self‐consistent earthquake fault‐scaling
+           relations: Update and extension to stable continental strike‐slip
+           faults." Bulletin of the Seismological Society of America 104.6
+           (2014): 2953-2965.
+
     """
     a_strike_slip_small = sp.stats.norm(loc=4.16, scale=0.39).rvs() if random else 4.17
     b_strike_slip_small = 1.667
@@ -214,6 +222,14 @@ def leonard_magnitude_to_width(
     -------
     float
             Width of the fault. (km)
+
+    References
+    ----------
+    .. [0] Leonard, Mark. "Self‐consistent earthquake fault‐scaling
+           relations: Update and extension to stable continental strike‐slip
+           faults." Bulletin of the Seismological Society of America 104.6
+           (2014): 2953-2965.
+
     """
     a_strike_slip_small = (
         sp.stats.norm(loc=3.885, scale=0.065).rvs() if random else 3.88
@@ -255,6 +271,13 @@ def leonard_magnitude_to_length_width(
     -------
     tuple[float, float]
         Length and width of the fault.
+
+    References
+    ----------
+    .. [0] Leonard, Mark. "Self‐consistent earthquake fault‐scaling
+           relations: Update and extension to stable continental strike‐slip
+           faults." Bulletin of the Seismological Society of America 104.6
+           (2014): 2953-2965.
     """
     area = leonard_magnitude_to_area(magnitude, rake, random)
     length = leonard_magnitude_to_length(magnitude, rake, random)
@@ -436,6 +459,11 @@ def contreras_interface_magnitude_to_length_width(
     -------
     tuple[float, float]
             Length and width of the fault.
+
+    References
+    ----------
+    .. [0] Contreras, Victor, et al. "NGA-Sub source and path database." Earthquake Spectra 38.2 (2022): 799-840.
+
     """
     area = contreras_interface_magnitude_to_area(magnitude, random)
     aspect_ratio = contreras_interface_magnitude_to_aspect_ratio(magnitude, random)
@@ -577,6 +605,13 @@ def contreras_slab_magnitude_to_length_width(
     -------
     tuple[float, float]
         Length and width of the fault.
+
+    References
+    ----------
+    .. [0] Bozorgnia, Y., & Stewart, J.P. (2020). Data Resources for
+           NGA-Subduction Project (Report No. 2020/02). Pacific Earthquake
+           Engineering Research Center (PEER).
+           https://doi.org/10.55461/RDWC6463
     """
     area = strasser_slab_magnitude_to_area(magnitude, random)
     aspect_ratio = contreras_slab_magnitude_to_aspect_ratio(magnitude, random)

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -593,7 +593,7 @@ def contreras_slab_magnitude_to_aspect_ratio(
     """
     if magnitude < 5:
         warnings.warn(
-            "Magnitude out of range for Contreras model, minimum magnitude is 6"
+            "Magnitude out of range for Contreras model, minimum magnitude is 5"
         )
     a_3 = 0.216
     m_1 = 6.5

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -1,6 +1,7 @@
 """Magnitude scaling relationships for fault dimensions."""
 
 import functools
+import warnings
 from enum import Enum, StrEnum, auto
 
 import numpy as np
@@ -223,6 +224,11 @@ def leonard_magnitude_to_width(
     float
             Width of the fault. (km)
 
+    Warns
+    -----
+    UserWarning
+            If the width is out of range for the Leonard model.
+
     References
     ----------
     .. [0] Leonard, Mark. "Self‐consistent earthquake fault‐scaling
@@ -239,13 +245,13 @@ def leonard_magnitude_to_width(
     if rake_type(rake) == RakeType.STRIKE_SLIP:
         width = 10 ** ((magnitude - a_strike_slip_small) / b_strike_slip_small)
         if width > 19.0 or width < 3.4:
-            raise ValueError("Width out of range for Leonard model.")
+            warnings.warn("Width out of range for Leonard model.")
     else:
         a_dip_slip_small = sp.stats.norm(loc=3.67, scale=0.06).rvs() if random else 3.63
         b_dip_slip_small = 2.5
         width = 10 ** ((magnitude - a_dip_slip_small) / b_dip_slip_small)
         if width <= 5.4:
-            raise ValueError("Width out of range for Leonard model.")
+            warnings.warn("Width out of range for Leonard model.")
 
     return width
 
@@ -324,9 +330,9 @@ def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> 
     float
         Moment magnitude of the fault.
 
-    Raises
-    ------
-    ValueError
+    Warns
+    -----
+    UserWarning
         If the area is less than the minimum area of 137.76 km^2.
 
     Notes
@@ -342,8 +348,8 @@ def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> 
            subduction-zone earthquakes with moment magnitude." Seismological
            Research Letters 81.6 (2010): 941-950.
     """
-    if area < 137:
-        raise ValueError(
+    if area < 137.76:
+        warnings.warn(
             "Area out of range for Contreras model, minimum area is 137.76 km^2"
         )
     sigma_a = sp.stats.norm(loc=0, scale=0.73).rvs() if random else 0
@@ -370,9 +376,9 @@ def contreras_interface_magnitude_to_area(
     float
         Area of the fault. (km^2)
 
-    Raises
-    ------
-    ValueError
+    Warns
+    -----
+    UserWarning
         If the magnitude is less than the minimum magnitude of 6.
 
     Notes
@@ -389,7 +395,7 @@ def contreras_interface_magnitude_to_area(
            Research Letters 81.6 (2010): 941-950.
     """
     if magnitude < 6:
-        raise ValueError(
+        warnings.warn(
             "Magnitude out of range for Contreras model, minimum magnitude is 6"
         )
     sigma_a = sp.stats.norm(loc=0, scale=0.73).rvs() if random else 0
@@ -416,9 +422,9 @@ def contreras_interface_magnitude_to_aspect_ratio(
     float
         Aspect ratio of the fault.
 
-    Raises
-    ------
-    ValueError
+    Warns
+    -----
+    UserWarning
         If the magnitude is less than the minimum magnitude of 6.
 
     References
@@ -426,7 +432,7 @@ def contreras_interface_magnitude_to_aspect_ratio(
     .. [0] Contreras, Victor, et al. "NGA-Sub source and path database." Earthquake Spectra 38.2 (2022): 799-840.
     """
     if magnitude < 6:
-        raise ValueError(
+        warnings.warn(
             "Magnitude out of range for Contreras model, minimum magnitude is 6"
         )
     a_3 = 0.6248
@@ -486,10 +492,10 @@ def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> float:
     float
         Moment magnitude of the fault.
 
-    Raises
-    ------
-    ValueError
-        If the area is less than the minimum area of 137.76 km^2.
+    Warns
+    -----
+    UserWarning
+        If the area is not between the minimum and maximum area of the Strasser model, estimated at 130km^2 and 5212km^2.
 
     References
     ----------
@@ -503,7 +509,7 @@ def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> float:
     lower_bound = 130
     upper_bound = 5212
     if not (lower_bound <= area <= upper_bound):
-        raise ValueError(
+        warnings.warn(
             f"Area out of range for Strasser model, area must be between {lower_bound} and {upper_bound} km^2."
         )
 
@@ -531,9 +537,9 @@ def strasser_slab_magnitude_to_area(magnitude: float, random: bool = False) -> f
     float
         Area of the fault. (km^2)
 
-    Raises
-    ------
-    ValueError
+    Warns
+    -----
+    UserWarning
         If the magnitude is less than the minimum magnitude of 5.9 or
         larger than the maximum magnitude of 7.8.
 
@@ -545,7 +551,7 @@ def strasser_slab_magnitude_to_area(magnitude: float, random: bool = False) -> f
            Research Letters 81.6 (2010): 941-950.
     """
     if not (5.9 <= magnitude <= 7.8):
-        raise ValueError(
+        warnings.warn(
             "Magnitude out of range for Strasser model, magnitude must be between 5.9 and 7.8"
         )
     a = -3.225
@@ -573,9 +579,9 @@ def contreras_slab_magnitude_to_aspect_ratio(
     float
         Aspect ratio of the fault.
 
-    Raises
-    ------
-    ValueError
+    Warns
+    -----
+    UserWarning
         If the magnitude is less than the minimum magnitude of 5.
 
     References
@@ -586,7 +592,7 @@ def contreras_slab_magnitude_to_aspect_ratio(
            https://doi.org/10.55461/RDWC6463
     """
     if magnitude < 5:
-        raise ValueError(
+        warnings.warn(
             "Magnitude out of range for Contreras model, minimum magnitude is 6"
         )
     a_3 = 0.216
@@ -658,7 +664,7 @@ def magnitude_to_length_width(
             Length and width of the fault estimated by the scaling relation.
     """
     if scaling_relation == ScalingRelation.LEONARD2014 and rake is None:
-        raise ValueError("Rake must be specified for Leonard scaling.")
+        warnings.warn("Rake must be specified for Leonard scaling.")
     scaling_relations_map = {
         ScalingRelation.LEONARD2014: functools.partial(
             leonard_magnitude_to_length_width, rake=rake, random=random
@@ -692,6 +698,11 @@ def magnitude_to_area(
     random : bool, optional
         If True, sample parameters according to uncertainties in the
         paper, otherwise use the mean values. Default is False.
+
+    Raises
+    ------
+    ValueError
+        If `scaling_relation` is `LEONARD2014` and `rake` is not specified.
 
     Returns
     -------

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -83,7 +83,7 @@ def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) ->
     -----
     If the rake is not strike-slip, the uncertainties are assymetric.
     Hence, setting `random = False` is not equivalent to using the
-    mean value for the parameters for all faults. Paremeter values are
+    mean value for the parameters for all faults. Parameter values are
     found in Table 4 of [0]_.
 
     References

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -29,7 +29,7 @@ class ScalingRelation(StrEnum):
 MAGNITUDE_BOUNDS = {
     ScalingRelation.LEONARD2014: (4.0, 9.0),
     ScalingRelation.CONTRERAS_INTERFACE2017: (6.0, 9.0),
-    ScalingRelation.CONTRERAS_SLAB2020: (5.0, 9.0),
+    ScalingRelation.CONTRERAS_SLAB2020: (5.9, 7.8),
 }
 
 
@@ -498,6 +498,15 @@ def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> float:
            subduction-zone earthquakes with moment magnitude." Seismological
            Research Letters 81.6 (2010): 941-950.
     """
+
+    # lower bound and upper bound for the area are estimated from the minimum and maximum magnitude of the Strasser model.
+    lower_bound = 130
+    upper_bound = 5212
+    if not (lower_bound <= area <= upper_bound):
+        raise ValueError(
+            f"Area out of range for Strasser model, area must be between {lower_bound} and {upper_bound} km^2."
+        )
+
     a = 4.054
     b = 0.981
     sigma_a = sp.stats.norm(loc=0, scale=0.288).rvs() if random else 0
@@ -525,7 +534,8 @@ def strasser_slab_magnitude_to_area(magnitude: float, random: bool = False) -> f
     Raises
     ------
     ValueError
-        If the magnitude is less than the minimum magnitude of 6.
+        If the magnitude is less than the minimum magnitude of 5.9 or
+        larger than the maximum magnitude of 7.8.
 
     References
     ----------
@@ -534,6 +544,10 @@ def strasser_slab_magnitude_to_area(magnitude: float, random: bool = False) -> f
            subduction-zone earthquakes with moment magnitude." Seismological
            Research Letters 81.6 (2010): 941-950.
     """
+    if not (5.9 <= magnitude <= 7.8):
+        raise ValueError(
+            "Magnitude out of range for Strasser model, magnitude must be between 5.9 and 7.8"
+        )
     a = -3.225
     sigma_a = sp.stats.norm(loc=0, scale=0.598).rvs() if random else 0
     b = 0.890

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -259,6 +259,13 @@ def leonard_magnitude_to_length_width(
     length = leonard_magnitude_to_length(magnitude, rake, random)
     width = leonard_magnitude_to_width(magnitude, rake, random)
     aspect_ratio = max(length / width, 1)
+    return area_aspect_ratio_to_length_width(area, aspect_ratio)
+
+
+def area_aspect_ratio_to_length_width(
+    area: float, aspect_ratio: float
+) -> tuple[float, float]:
+    """Convert area and aspect ratio to length and width."""
     width = np.sqrt(area / aspect_ratio)
     length = area / width
     return length, width
@@ -418,9 +425,7 @@ def contreras_interface_magnitude_to_length_width(
     """
     area = contreras_interface_magnitude_to_area(magnitude, random)
     aspect_ratio = contreras_interface_magnitude_to_aspect_ratio(magnitude, random)
-    width = np.sqrt(area / aspect_ratio)
-    length = area / width
-    return length, width
+    return area_aspect_ratio_to_length_width(area, aspect_ratio)
 
 
 def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> float:
@@ -561,9 +566,7 @@ def contreras_slab_magnitude_to_length_width(
     """
     area = strasser_slab_magnitude_to_area(magnitude, random)
     aspect_ratio = contreras_slab_magnitude_to_aspect_ratio(magnitude, random)
-    width = np.sqrt(area / aspect_ratio)
-    length = area / width
-    return length, width
+    return area_aspect_ratio_to_length_width(area, aspect_ratio)
 
 
 def magnitude_to_length_width(

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -260,7 +260,7 @@ def leonard_magnitude_to_length_width(
     width = leonard_magnitude_to_width(magnitude, rake, random)
     aspect_ratio = max(length / width, 1)
     width = np.sqrt(area / aspect_ratio)
-    length = width * aspect_ratio
+    length = area / width
     return length, width
 
 
@@ -419,7 +419,7 @@ def contreras_interface_magnitude_to_length_width(
     area = contreras_interface_magnitude_to_area(magnitude, random)
     aspect_ratio = contreras_interface_magnitude_to_aspect_ratio(magnitude, random)
     width = np.sqrt(area / aspect_ratio)
-    length = width * aspect_ratio
+    length = area / width
     return length, width
 
 
@@ -562,7 +562,7 @@ def contreras_slab_magnitude_to_length_width(
     area = strasser_slab_magnitude_to_area(magnitude, random)
     aspect_ratio = contreras_slab_magnitude_to_aspect_ratio(magnitude, random)
     width = np.sqrt(area / aspect_ratio)
-    length = width * aspect_ratio
+    length = area / width
     return length, width
 
 

--- a/tests/test_magnitude_scaling.py
+++ b/tests/test_magnitude_scaling.py
@@ -8,7 +8,7 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 import scipy as sp
-from hypothesis import given
+from hypothesis import assume, given
 
 from source_modelling import magnitude_scaling
 
@@ -222,7 +222,7 @@ def test_strasser_slab_expected_area(mw: float, expected_area: float):
     )
 
 
-@given(st.floats(min_value=6.0, max_value=9.5))
+@given(st.floats(min_value=5.9, max_value=7.7))
 def test_strasser_monotonicity(mag1: float):
     mag2 = mag1 + 0.1  # Slightly higher magnitude
     assert magnitude_scaling.strasser_slab_magnitude_to_area(
@@ -237,7 +237,12 @@ def test_monotonicity_mag_to_area(
     ],
 ):
     """Test that the area is monotonic with respect to the magnitude."""
+
     scaling_relation, rake, magnitude = relation_with_magnitude
+    assume(
+        scaling_relation != magnitude_scaling.ScalingRelation.CONTRERAS_SLAB2020
+        or magnitude <= 7.7
+    )
     if scaling_relation == magnitude_scaling.ScalingRelation.LEONARD2014:
         mag_to_area = functools.partial(MAGNITUDE_TO_AREA[scaling_relation], rake=rake)
     else:
@@ -337,8 +342,8 @@ def test_normal_error_contreras_interface_mag_to_area(
         itertools.product(
             [magnitude_scaling.strasser_slab_area_to_magnitude],
             np.linspace(
-                magnitude_scaling.strasser_slab_magnitude_to_area(6.0),
-                magnitude_scaling.strasser_slab_magnitude_to_area(9.0),
+                magnitude_scaling.strasser_slab_magnitude_to_area(5.9),
+                magnitude_scaling.strasser_slab_magnitude_to_area(7.8),
                 10,
             ),
         )
@@ -362,8 +367,8 @@ def test_normal_error_strasser_slab(area_to_mag: Callable[[float], float], area:
     itertools.product(
         [magnitude_scaling.strasser_slab_magnitude_to_area],
         np.linspace(
-            6.0,
-            9.0,
+            5.9,
+            7.8,
             5,
         ),
     ),

--- a/tests/test_magnitude_scaling.py
+++ b/tests/test_magnitude_scaling.py
@@ -1,0 +1,582 @@
+import functools
+import itertools
+import random
+from typing import Any, Callable
+from unittest.mock import patch
+
+import hypothesis.strategies as st
+import numpy as np
+import pytest
+import scipy as sp
+from hypothesis import assume, given
+
+from source_modelling import magnitude_scaling
+
+MAGNITUDE_TO_AREA = {
+    magnitude_scaling.ScalingRelation.LEONARD2014: magnitude_scaling.leonard_magnitude_to_area,
+    magnitude_scaling.ScalingRelation.CONTRERAS_INTERFACE2017: magnitude_scaling.contreras_interface_magnitude_to_area,
+    magnitude_scaling.ScalingRelation.CONTRERAS_SLAB2020: magnitude_scaling.strasser_slab_magnitude_to_area,
+}
+
+AREA_TO_MAGNITUDE = {
+    magnitude_scaling.ScalingRelation.LEONARD2014: magnitude_scaling.leonard_area_to_magnitude,
+    magnitude_scaling.ScalingRelation.CONTRERAS_INTERFACE2017: magnitude_scaling.contreras_interface_area_to_magnitude,
+    magnitude_scaling.ScalingRelation.CONTRERAS_SLAB2020: magnitude_scaling.strasser_slab_area_to_magnitude,
+}
+
+
+def seed(seed: int):
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        def wrapper(*args: list[Any], **kwargs: dict[str, Any]) -> Any:
+            random.seed(seed)
+            np.random.seed(seed)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def relation_with_magnitude(
+    relations: list[magnitude_scaling.ScalingRelation] = list(MAGNITUDE_TO_AREA),
+):
+    @st.composite
+    def sampler(
+        draw: st.DrawFn,
+    ) -> tuple[magnitude_scaling.ScalingRelation, float | None, float]:
+        scaling_relation = draw(st.sampled_from(relations))
+        min_magnitude, max_magnitude = magnitude_scaling.MAGNITUDE_BOUNDS[
+            scaling_relation
+        ]
+        if scaling_relation == magnitude_scaling.ScalingRelation.LEONARD2014:
+            rake = draw(st.floats(min_value=-180, max_value=180))
+        else:
+            rake = None
+
+        magnitude = draw(st.floats(min_value=min_magnitude, max_value=max_magnitude))
+        return scaling_relation, rake, magnitude
+
+    return sampler()
+
+
+# The contreras slab 2020 relation (which is the same as Strasser 2010) is not invertible. See the coefficients of Table 2 in the paper
+# Strasser, Fleur O., M. C. Arango, and Julian J. Bommer.
+# "Scaling of the source dimensions of interface and intraslab
+# subduction-zone earthquakes with moment magnitude." Seismological
+# Research Letters 81.6 (2010): 941-950.
+# The coefficients are not invertible, so we cannot test the inversion of the area to magnitude function.
+@given(
+    relation_with_magnitude(
+        [
+            magnitude_scaling.ScalingRelation.LEONARD2014,
+            magnitude_scaling.ScalingRelation.CONTRERAS_INTERFACE2017,
+        ]
+    )
+)
+def test_inversion(
+    relation_with_magnitude: tuple[
+        magnitude_scaling.ScalingRelation, float | None, float
+    ],
+):
+    """When executed with best-fit values, the magnitude to area function is an inverse of the area to magnitude function."""
+    scaling_relation, rake, magnitude = relation_with_magnitude
+    if scaling_relation == magnitude_scaling.ScalingRelation.LEONARD2014:
+        mag_to_area = functools.partial(MAGNITUDE_TO_AREA[scaling_relation], rake=rake)
+        area_to_mag = functools.partial(AREA_TO_MAGNITUDE[scaling_relation], rake=rake)
+    else:
+        mag_to_area = MAGNITUDE_TO_AREA[scaling_relation]
+        area_to_mag = AREA_TO_MAGNITUDE[scaling_relation]
+    assert area_to_mag(mag_to_area(magnitude)) == pytest.approx(magnitude)
+
+
+@pytest.mark.parametrize(
+    "mw, rake, expected_area",
+    [
+        (4.0, -180.0, 1.0232929922807537),
+        (4.0, -90.0, 1.0),
+        (4.0, 0.0, 1.0232929922807537),
+        (4.0, 90.0, 1.0),
+        (4.0, 180.0, 1.0232929922807537),
+        (5.25, -180.0, 18.197008586099827),
+        (5.25, -90.0, 17.78279410038923),
+        (5.25, 0.0, 18.197008586099827),
+        (5.25, 90.0, 17.78279410038923),
+        (5.25, 180.0, 18.197008586099827),
+        (6.5, -180.0, 323.5936569296281),
+        (6.5, -90.0, 316.22776601683796),
+        (6.5, 0.0, 323.5936569296281),
+        (6.5, 90.0, 316.22776601683796),
+        (6.5, 180.0, 323.5936569296281),
+        (7.75, -180.0, 5754.399373371566),
+        (7.75, -90.0, 5623.413251903491),
+        (7.75, 0.0, 5754.399373371566),
+        (7.75, 90.0, 5623.413251903491),
+        (7.75, 180.0, 5754.399373371566),
+        (9.0, -180.0, 102329.29922807537),
+        (9.0, -90.0, 100000.0),
+        (9.0, 0.0, 102329.29922807537),
+        (9.0, 90.0, 100000.0),
+        (9.0, 180.0, 102329.29922807537),
+    ],
+)
+def test_leonard_area(mw: float, rake: float, expected_area: float):
+    """Test the Leonard 2014 area calculation against values from the old implementation in qcore.
+
+    NOTE: this combined with the inversion test for leonard ensure that the area calculation is compatible with the old implementation as well."""
+    assert magnitude_scaling.magnitude_to_area(
+        magnitude_scaling.ScalingRelation.LEONARD2014, mw, rake
+    ) == pytest.approx(expected_area)
+
+
+@pytest.mark.parametrize(
+    "mw, expected_area",
+    [
+        (6.0, 130.31667784522986),
+        (6.036734693877551, 140.5056788423239),
+        (6.073469387755102, 151.49132185819374),
+        (6.110204081632653, 163.33589351998378),
+        (6.146938775510204, 176.10655042633059),
+        (6.183673469387755, 189.87569991324222),
+        (6.220408163265306, 204.72141059071683),
+        (6.257142857142857, 220.72785497777087),
+        (6.293877551020408, 237.98578674553698),
+        (6.330612244897959, 256.5930552743158),
+        (6.36734693877551, 276.6551604420244),
+        (6.404081632653061, 298.2858507896005),
+        (6.440816326530612, 321.6077684548422),
+        (6.477551020408163, 346.7531445313512),
+        (6.514285714285714, 373.86454879513593),
+        (6.551020408163265, 403.0956980496915),
+        (6.587755102040816, 434.6123276727276),
+        (6.624489795918367, 468.5931313060583),
+        (6.661224489795918, 505.23077401652745),
+        (6.697959183673469, 544.7329846724095),
+        (6.73469387755102, 587.3237337288654),
+        (6.771428571428571, 633.244503100285),
+        (6.808163265306122, 682.7556553194657),
+        (6.844897959183673, 736.1379097465132),
+        (6.881632653061224, 793.6939341973044),
+        (6.918367346938775, 855.7500610157631),
+        (6.955102040816326, 922.6581373197666),
+        (6.9918367346938775, 994.7975199112492),
+        (7.0285714285714285, 1072.577226161284),
+        (7.0653061224489795, 1156.4382530652758),
+        (7.1020408163265305, 1246.8560776168943),
+        (7.1387755102040815, 1344.3433526774159),
+        (7.1755102040816325, 1449.452813625574),
+        (7.2122448979591836, 1562.7804122681011),
+        (7.248979591836735, 1684.9686957796698),
+        (7.285714285714286, 1816.7104498302217),
+        (7.322448979591837, 1958.7526265555612),
+        (7.359183673469388, 2111.9005796421025),
+        (7.395918367346939, 2277.0226305379424),
+        (7.43265306122449, 2455.054991679859),
+        (7.469387755102041, 2647.0070746500464),
+        (7.506122448979592, 2853.9672133588942),
+        (7.542857142857143, 3077.1088347031946),
+        (7.579591836734694, 3317.697111686388),
+        (7.616326530612245, 3577.0961367227364),
+        (7.653061224489796, 3856.7766557968594),
+        (7.689795918367347, 4158.324407329888),
+        (7.726530612244898, 4483.449113032134),
+        (7.763265306122449, 4833.994171718779),
+        (7.8, 5211.947111050806),
+    ],
+)
+def test_strasser_slab_expected_area(mw: float, expected_area: float):
+    """Test the Strasser 2010 slab area calculation against values from the old implementation in qcore."""
+    assert magnitude_scaling.strasser_slab_magnitude_to_area(mw) == pytest.approx(
+        expected_area
+    )
+
+
+@given(st.floats(min_value=6.0, max_value=9.5))
+def test_strasser_monotonicity(mag1):
+    mag2 = mag1 + 0.1  # Slightly higher magnitude
+    assert magnitude_scaling.strasser_slab_magnitude_to_area(
+        mag2
+    ) > magnitude_scaling.strasser_slab_magnitude_to_area(mag1)
+
+
+@given(relation_with_magnitude())
+def test_monotonicity_mag_to_area(
+    relation_with_magnitude: tuple[
+        magnitude_scaling.ScalingRelation, float | None, float
+    ],
+):
+    """Test that the area is monotonic with respect to the magnitude."""
+    scaling_relation, rake, magnitude = relation_with_magnitude
+    if scaling_relation == magnitude_scaling.ScalingRelation.LEONARD2014:
+        mag_to_area = functools.partial(MAGNITUDE_TO_AREA[scaling_relation], rake=rake)
+    else:
+        mag_to_area = MAGNITUDE_TO_AREA[scaling_relation]
+    assert mag_to_area(magnitude + 0.1) > mag_to_area(magnitude)
+
+
+@pytest.mark.parametrize(
+    "area_to_mag, area",
+    list(
+        itertools.product(
+            [magnitude_scaling.contreras_interface_area_to_magnitude],
+            np.linspace(
+                magnitude_scaling.contreras_interface_magnitude_to_area(6.0),
+                magnitude_scaling.contreras_interface_magnitude_to_area(9.0),
+                10,
+            ),
+        )
+    ),
+)
+@seed(1)
+def test_normal_error_contreras_interface(
+    area_to_mag: Callable[[float], float], area: float
+):
+    """Generate samples with random = True set on area_to_mag and check that it approximates the value with random = False."""
+    samples = [area_to_mag(area, random=True) for _ in range(300)]
+    result = sp.stats.goodness_of_fit(
+        sp.stats.norm,
+        samples,
+        statistic="ad",
+        known_params=dict(loc=area_to_mag(area), scale=0.73 / np.log(10)),
+    )
+    assert result.pvalue > 0.05
+
+
+@pytest.mark.parametrize(
+    "aspect_ratio, magnitude",
+    list(
+        itertools.product(
+            [magnitude_scaling.contreras_interface_magnitude_to_aspect_ratio],
+            np.linspace(
+                6.0,
+                9.0,
+                10,
+            ),
+        )
+    ),
+)
+@seed(1)
+def test_normal_error_contreras_interface_aspect_ratio(
+    aspect_ratio: Callable[[float], float], magnitude: float
+):
+    """Generate samples with random = True set on area_to_mag and check that it approximates the value with random = False."""
+    samples = np.array([aspect_ratio(magnitude, random=True) for _ in range(100)])
+    sigma = 0.32 if magnitude < 7.25 else 0.47
+    result = sp.stats.goodness_of_fit(
+        sp.stats.norm,
+        np.log(samples),
+        statistic="ad",
+        known_params=dict(loc=np.log(aspect_ratio(magnitude)), scale=sigma),
+    )
+    assert result.pvalue > 0.05
+
+
+# NOTE: Because magnitude is normally distributed, the area is log-normally distributed. We test for normality of the log of the area.
+
+
+@pytest.mark.parametrize(
+    "mag_to_area, magnitude",
+    itertools.product(
+        [magnitude_scaling.contreras_interface_magnitude_to_area],
+        np.linspace(
+            6.0,
+            9.0,
+            5,
+        ),
+    ),
+)
+@seed(1)
+def test_normal_error_contreras_interface_mag_to_area(
+    mag_to_area: Callable[[float], float], magnitude: float
+):
+    """Generate samples with random = True set on mag_to_area and check that it approximates the value with random = False."""
+    samples = [mag_to_area(magnitude, random=True) for _ in range(100)]
+
+    result = sp.stats.goodness_of_fit(
+        sp.stats.lognorm,
+        samples,
+        statistic="ks",
+    )
+    assert result.pvalue > 0.05
+
+
+@pytest.mark.parametrize(
+    "area_to_mag, area",
+    list(
+        itertools.product(
+            [magnitude_scaling.strasser_slab_area_to_magnitude],
+            np.linspace(
+                magnitude_scaling.strasser_slab_magnitude_to_area(6.0),
+                magnitude_scaling.strasser_slab_magnitude_to_area(9.0),
+                10,
+            ),
+        )
+    ),
+)
+@seed(1)
+def test_normal_error_strasser_slab(area_to_mag: Callable[[float], float], area: float):
+    """Generate samples with random = True set on area_to_mag and check that it approximates the value with random = False."""
+    samples = [area_to_mag(area, random=True) for _ in range(100)]
+    result = sp.stats.goodness_of_fit(
+        sp.stats.norm,
+        samples,
+        statistic="ad",
+        known_params=dict(loc=area_to_mag(area)),
+    )
+    assert result.pvalue > 0.05
+
+
+@pytest.mark.parametrize(
+    "mag_to_area, magnitude",
+    itertools.product(
+        [magnitude_scaling.strasser_slab_magnitude_to_area],
+        np.linspace(
+            6.0,
+            9.0,
+            5,
+        ),
+    ),
+)
+@seed(1)
+def test_normal_error_strasser_slab_mag_to_area(
+    mag_to_area: Callable[[float], float], magnitude: float
+):
+    """Generate samples with random = True set on mag_to_area and check that it approximates the value with random = False."""
+    samples = [mag_to_area(magnitude, random=True) for _ in range(100)]
+    result = sp.stats.goodness_of_fit(
+        sp.stats.lognorm,
+        samples,
+        statistic="ks",
+    )
+    assert result.pvalue > 0.05
+
+
+@pytest.mark.parametrize(
+    "aspect_ratio, magnitude",
+    list(
+        itertools.product(
+            [magnitude_scaling.contreras_slab_magnitude_to_aspect_ratio],
+            np.linspace(
+                6.0,
+                9.0,
+                10,
+            ),
+        )
+    ),
+)
+@seed(1)
+def test_normal_error_contreras_slab_aspect_ratio(
+    aspect_ratio: Callable[[float], float], magnitude: float
+):
+    """Generate samples with random = True set on area_to_mag and check that it approximates the value with random = False."""
+    samples = np.array([aspect_ratio(magnitude, random=True) for _ in range(100)])
+    sigma = 0.24 if magnitude < 6.5 else 0.38
+    result = sp.stats.goodness_of_fit(
+        sp.stats.norm,
+        np.log(samples),
+        statistic="ad",
+        known_params=dict(loc=np.log(aspect_ratio(magnitude)), scale=sigma),
+    )
+    assert result.pvalue > 0.05
+
+
+@pytest.mark.parametrize(
+    "area_to_mag, rake, area",
+    list(
+        itertools.product(
+            [magnitude_scaling.leonard_area_to_magnitude],
+            np.linspace(-180, 180, 10),
+            np.linspace(
+                10,
+                10**5,
+                10,
+            ),
+        )
+    ),
+)
+@seed(1)
+def test_normal_error_leonard(
+    area_to_mag: Callable[[float], float], rake: float, area: float
+):
+    """Generate samples with random = True set on area_to_mag and check that it approximates the value with random = False."""
+    samples = [area_to_mag(area, rake=rake, random=True) for _ in range(100)]
+    result = sp.stats.goodness_of_fit(
+        sp.stats.norm,
+        samples,
+        statistic="ad",
+        # NOTE: We cannot assume a mean and standard deviation because these are assymetric values. So we just test for normality.
+    )
+    assert result.pvalue > 0.05
+
+
+@pytest.mark.parametrize(
+    "relations, magnitude",
+    itertools.product(
+        [
+            (
+                magnitude_scaling.contreras_slab_magnitude_to_length_width,
+                magnitude_scaling.strasser_slab_magnitude_to_area,
+            ),
+            (
+                magnitude_scaling.contreras_interface_magnitude_to_length_width,
+                magnitude_scaling.contreras_interface_magnitude_to_area,
+            ),
+        ],
+        np.linspace(6.0, 9.0, 10),
+    ),
+)
+def test_area_preservation_lw(
+    relations: tuple[Callable[[float], tuple[float, float]], Callable[[float], float]],
+    magnitude: float,
+):
+    """Test that the area is preserved when converting between area and length/width."""
+    magnitude_to_lw, magnitude_to_area = relations
+    area = magnitude_to_area(
+        magnitude,
+    )
+    length, width = magnitude_to_lw(
+        magnitude,
+    )
+    assert length * width == pytest.approx(area)
+
+
+@pytest.mark.parametrize(
+    "rake, magnitude",
+    itertools.product(
+        np.linspace(-180, 180, 10),
+        np.linspace(5.5, 7, 10),
+    ),
+)
+def test_area_preservation_lw_leonard(
+    rake: float,
+    magnitude: float,
+):
+    """Test that the area is preserved when converting between area and length/width."""
+    area = magnitude_scaling.leonard_magnitude_to_area(magnitude, rake)
+    length, width = magnitude_scaling.leonard_magnitude_to_length_width(
+        magnitude,
+        rake,
+    )
+    assert length * width == pytest.approx(area)
+
+
+@given(
+    area=st.floats(1, 10**5),
+    aspect_ratio=st.floats(0.1, 10),
+)
+def test_length_width(area: float, aspect_ratio: float):
+    """Test that the length and width are correct (Sanity check!)."""
+    length, width = magnitude_scaling.area_aspect_ratio_to_length_width(
+        area, aspect_ratio
+    )
+    assert length * width == pytest.approx(area)
+    assert length / width == pytest.approx(aspect_ratio)
+
+
+@pytest.mark.parametrize(
+    "scaling_relation, func_name, rake_required",
+    [
+        (
+            magnitude_scaling.ScalingRelation.LEONARD2014,
+            "leonard_magnitude_to_length_width",
+            True,
+        ),
+        (
+            magnitude_scaling.ScalingRelation.CONTRERAS_INTERFACE2017,
+            "contreras_interface_magnitude_to_length_width",
+            False,
+        ),
+        (
+            magnitude_scaling.ScalingRelation.CONTRERAS_SLAB2020,
+            "contreras_slab_magnitude_to_length_width",
+            False,
+        ),
+    ],
+)
+def test_magnitude_to_length_width_calls_correct_function(
+    scaling_relation, func_name, rake_required
+):
+    magnitude = 7.0
+    rake = 90.0 if rake_required else None
+    random = True
+
+    with patch(f"source_modelling.magnitude_scaling.{func_name}") as mock_func:
+        magnitude_scaling.magnitude_to_length_width(
+            scaling_relation, magnitude, rake, random
+        )
+        if rake_required:
+            mock_func.assert_called_once_with(magnitude, rake=rake, random=random)
+        else:
+            mock_func.assert_called_once_with(magnitude, random=random)
+
+
+@pytest.mark.parametrize(
+    "scaling_relation, func_name, rake_required",
+    [
+        (
+            magnitude_scaling.ScalingRelation.LEONARD2014,
+            "leonard_magnitude_to_area",
+            True,
+        ),
+        (
+            magnitude_scaling.ScalingRelation.CONTRERAS_INTERFACE2017,
+            "contreras_interface_magnitude_to_area",
+            False,
+        ),
+        (
+            magnitude_scaling.ScalingRelation.CONTRERAS_SLAB2020,
+            "strasser_slab_magnitude_to_area",
+            False,
+        ),
+    ],
+)
+def test_magnitude_to_area_calls_correct_function(
+    scaling_relation, func_name, rake_required
+):
+    magnitude = 7.0
+    rake = 90.0 if rake_required else None
+    random = True
+
+    with patch(f"source_modelling.magnitude_scaling.{func_name}") as mock_func:
+        magnitude_scaling.magnitude_to_area(scaling_relation, magnitude, rake, random)
+        if rake_required:
+            mock_func.assert_called_once_with(magnitude, rake=rake, random=random)
+        else:
+            mock_func.assert_called_once_with(magnitude, random=random)
+
+
+@pytest.mark.parametrize(
+    "scaling_relation, func_name, rake_required",
+    [
+        (
+            magnitude_scaling.ScalingRelation.LEONARD2014,
+            "leonard_area_to_magnitude",
+            True,
+        ),
+        (
+            magnitude_scaling.ScalingRelation.CONTRERAS_INTERFACE2017,
+            "contreras_interface_area_to_magnitude",
+            False,
+        ),
+        (
+            magnitude_scaling.ScalingRelation.CONTRERAS_SLAB2020,
+            "strasser_slab_area_to_magnitude",
+            False,
+        ),
+    ],
+)
+def test_area_to_magnitude_calls_correct_function(
+    scaling_relation: magnitude_scaling.ScalingRelation,
+    func_name: str,
+    rake_required: bool,
+):
+    area = 1000.0  # Example fault area in km^2
+    rake = 90.0 if rake_required else None
+    random = True
+
+    with patch(f"source_modelling.magnitude_scaling.{func_name}") as mock_func:
+        magnitude_scaling.area_to_magnitude(scaling_relation, area, rake, random)
+        if rake_required:
+            mock_func.assert_called_once_with(area, rake=rake, random=random)
+        else:
+            mock_func.assert_called_once_with(area, random=random)

--- a/tests/test_magnitude_scaling.py
+++ b/tests/test_magnitude_scaling.py
@@ -342,8 +342,8 @@ def test_normal_error_contreras_interface_mag_to_area(
         itertools.product(
             [magnitude_scaling.strasser_slab_area_to_magnitude],
             np.linspace(
-                magnitude_scaling.strasser_slab_magnitude_to_area(5.9),
-                magnitude_scaling.strasser_slab_magnitude_to_area(7.8),
+                130,
+                5212,
                 10,
             ),
         )
@@ -458,7 +458,7 @@ def test_normal_error_leonard(
                 magnitude_scaling.contreras_interface_magnitude_to_area,
             ),
         ],
-        np.linspace(6.0, 9.0, 10),
+        np.linspace(6, 7.8, 10),
     ),
 )
 def test_area_preservation_lw(

--- a/tests/test_magnitude_scaling.py
+++ b/tests/test_magnitude_scaling.py
@@ -8,7 +8,7 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 import scipy as sp
-from hypothesis import assume, given
+from hypothesis import given
 
 from source_modelling import magnitude_scaling
 
@@ -36,6 +36,37 @@ def seed(seed: int):
         return wrapper
 
     return decorator
+
+
+@pytest.mark.parametrize(
+    "rake, expected",
+    [
+        (-30, magnitude_scaling.RakeType.STRIKE_SLIP),
+        (0, magnitude_scaling.RakeType.STRIKE_SLIP),
+        (30, magnitude_scaling.RakeType.STRIKE_SLIP),
+        (150, magnitude_scaling.RakeType.STRIKE_SLIP),
+        (210, magnitude_scaling.RakeType.STRIKE_SLIP),
+        (60, magnitude_scaling.RakeType.REVERSE),
+        (90, magnitude_scaling.RakeType.REVERSE),
+        (120, magnitude_scaling.RakeType.REVERSE),
+        (-120, magnitude_scaling.RakeType.NORMAL),
+        (-90, magnitude_scaling.RakeType.NORMAL),
+        (-60, magnitude_scaling.RakeType.NORMAL),
+        (-149, magnitude_scaling.RakeType.NORMAL_OBLIQUE),
+        (-121, magnitude_scaling.RakeType.NORMAL_OBLIQUE),
+        (-59, magnitude_scaling.RakeType.NORMAL_OBLIQUE),
+        (-31, magnitude_scaling.RakeType.NORMAL_OBLIQUE),
+        (31, magnitude_scaling.RakeType.REVERSE_OBLIQUE),
+        (59, magnitude_scaling.RakeType.REVERSE_OBLIQUE),
+        (121, magnitude_scaling.RakeType.REVERSE_OBLIQUE),
+        (149, magnitude_scaling.RakeType.REVERSE_OBLIQUE),
+        (-200, magnitude_scaling.RakeType.UNDEFINED),
+        (250, magnitude_scaling.RakeType.UNDEFINED),
+        (999, magnitude_scaling.RakeType.UNDEFINED),
+    ],
+)
+def test_rake_type(rake: float, expected: magnitude_scaling.RakeType):
+    assert magnitude_scaling.rake_type(rake) == expected
 
 
 def relation_with_magnitude(
@@ -192,7 +223,7 @@ def test_strasser_slab_expected_area(mw: float, expected_area: float):
 
 
 @given(st.floats(min_value=6.0, max_value=9.5))
-def test_strasser_monotonicity(mag1):
+def test_strasser_monotonicity(mag1: float):
     mag2 = mag1 + 0.1  # Slightly higher magnitude
     assert magnitude_scaling.strasser_slab_magnitude_to_area(
         mag2
@@ -494,7 +525,9 @@ def test_length_width(area: float, aspect_ratio: float):
     ],
 )
 def test_magnitude_to_length_width_calls_correct_function(
-    scaling_relation, func_name, rake_required
+    scaling_relation: magnitude_scaling.ScalingRelation,
+    func_name: str,
+    rake_required: bool,
 ):
     magnitude = 7.0
     rake = 90.0 if rake_required else None
@@ -531,7 +564,9 @@ def test_magnitude_to_length_width_calls_correct_function(
     ],
 )
 def test_magnitude_to_area_calls_correct_function(
-    scaling_relation, func_name, rake_required
+    scaling_relation: magnitude_scaling.ScalingRelation,
+    func_name: str,
+    rake_required: bool,
 ):
     magnitude = 7.0
     rake = 90.0 if rake_required else None

--- a/tests/test_magnitude_scaling.py
+++ b/tests/test_magnitude_scaling.py
@@ -1,7 +1,8 @@
 import functools
 import itertools
 import random
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import patch
 
 import hypothesis.strategies as st


### PR DESCRIPTION
This module, whose eventual purpose is to replace the old `qcore.mag_scaling` module implements magnitude scaling relationships with uncertainties. Unlike the old module, these uncertainties are extensively tested. The tests are the more important part as the code is extremely simple but technically complex. I have tested:

1. The leonard 2014 and strasser slab scaling relationships match with their old values from qcore.
2. Monotonicity of all scaling relationships.
3. That the magnitude to length, width relationships return a length and width with the sample aspect ratio.
4. For every function with randomisation a statistical test is applied that checks that the magnitude, area, and aspect ratio sampling matches the expected distribution of these values. That is:
   - Magnitude is normally distributed with parameters from the paper.
   - Area is log-normally distributed.
   - Aspect ratio is log-normally distributed.

   These tests also check that calling each relation with `random=False` is equivalent to taking the mean of a significant sample size where `random=True` (except for Leonard as his errors are assymetric).
5. That the primary interface to the module, the parameterised `magnitude_to_length_width`, `magnitude_to_area` and `area_to_magnitude` functions call the correct scaling relationship in the background.