### PR TITLE
Two-stage Fault Connectivity Check

### DIFF
--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -989,7 +989,7 @@ class Fault:
                 "Fault planes are connected, but not in a line."
                 " This can occur with very short segments."
                 " Trying to safely reduce the connectivity graph."
-                " Check the output faults carefully."
+                " Check the output fault carefully."
             )
             self._validate_fault_plane_connectivity(
                 nx.transitive_reduction(points_into_graph)

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -20,6 +20,7 @@ import copy
 import dataclasses
 import itertools
 import json
+import warnings
 from typing import Optional, Self
 
 import networkx as nx
@@ -920,6 +921,7 @@ class Fault:
                 continue
             else:
                 raise ValueError("Fault planes must be connected in a line.")
+
         if not (start_nodes == 1 and end_nodes == 1):
             raise ValueError("Fault planes must be connected in a line.")
 
@@ -977,7 +979,21 @@ class Fault:
         points_into_graph: nx.DiGraph = nx.from_dict_of_lists(
             points_into_relation, create_using=nx.DiGraph
         )
-        self._validate_fault_plane_connectivity(points_into_graph)
+        try:
+            self._validate_fault_plane_connectivity(points_into_graph)
+        except ValueError:
+            # Sometimes, faults with small segments can confuse the
+            # connectivity check, so we can apply a transitive
+            # reduction and then do the check again (with a warning).
+            warnings.warn(
+                "Fault planes are connected, but not in a line."
+                " This can occur with very short segments."
+                " Trying to safely reduce the connectivity graph."
+                " Check the output faults carefully."
+            )
+            self._validate_fault_plane_connectivity(
+                nx.transitive_reduction(points_into_graph)
+            )
 
         # Now that we have established the planes line up correctly, we can
         # obtain the line in question with a topological sort, which will

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -482,6 +482,29 @@ def test_both_dip_dir_provided():
         Plane.from_nztm_trace(trace_points, 0, 1, 45, dip_dir=90, dip_dir_nztm=90)
 
 
+def test_fault_with_short_segments():
+    """Check that a fault containing a less than 10m segment between two other segments does not raise an error."""
+    trace_points_offset = np.array(
+        [
+            [0, 0],
+            [100, 0],
+            [2, 0],
+            [300, 0],
+        ]
+    ).cumsum(axis=0)
+    trace_points_nztm = (
+        coordinates.wgs_depth_to_nztm(np.array([-43.0, 172.0])) + trace_points_offset
+    )
+    planes = [
+        Plane.from_nztm_trace(
+            trace_points_nztm[i : i + 2], dip=90, dtop=0, dbottom=10, dip_dir=90
+        )
+        for i in range(len(trace_points_nztm) - 1)
+    ]
+    with pytest.warns(UserWarning):
+        _ = Fault(planes)
+
+
 @pytest.mark.parametrize(
     "centroid, strike, dip, dip_dir, length, width, dtop, dbottom",
     [


### PR DESCRIPTION
This PR adds a fallback check to the fault connectivity checker. This fallback check is designed to make it easier to construct faults with very small segments.

## What Does the Fault Connectivity Check Do?

Faults are a series of connected planes. The planes should be connected along-strike and in a line, that is if `plane_1` points to `plane_2` and `plane_2` points to `plane_3` (along-strike), then the fault containing planes 1, 2, and 3 should be instantiated `Fault([plane_1, plane_2, plane_3])`. In a perfect world faults from all sources including the National Seismic Hazard Model, community fault model, and custom geometries would be specified like this. Unfortunately the world is far from perfect and instead faults are called with an arbitrary order of planes like `Fault([plane_2, plane_1, plane_3])`. So we must sort sort them ourselves.

## How Does the Sorting Work?

The sorting works by building a graph with an edge between indices `i` and `j` of the input list if the rightmost top corner of `plane_i` is *close to* the leftmost top corner of `plane_j`. For the above fault with planes passed as a list `[plane_2, plane_1, plane_3]` the graph constructed would look like `1 --> 0 --> 2`. The sorting is then a *topological sort* applied to this graph to get the sorted list of planes `[plane_1, plane_2, plane_3]`. Notably, we also check before this stage that **the graph is a line**. If the graph is not connected, or contains cycles, then that tells us the fault planes given do not make a fault consistent with the assumptions of the `Fault` class. We raise a `ValueError` in these cases.

## What is the Problem?

There are three ways a fault can be invalid:

1. The fault planes are disconnected. This happens if the planes have inconsistent strikes (think two planes next to each other with strikes 180 degrees apart), or the planes are far apart.
2. The fault planes are connected, but the planes point into each other cyclically. Think a triangle of fault planes pointing into each other in a circle.
3. The fault planes have really short segments.

That last problem is artificial. The *close to* check we do when sorting the faults needs to have some leeway to admit faults that have rounded corners or other numerical imprecision. This in turn means that sometimes fault planes are erroneously believed to point into more than one plane downstream. For instance,

```
|    Plane 1   | 2 |    Plane 3   |
```

which might get the graph `1 -> [2, 3], 2 -> 3`. We then throw a `ValueError` to reject this fault. A simple fix is adjusting the *close to* check to be more careful about which planes are considering pointing into each other, but then that causes more faults to be rejected of the first type. The NSHM is full of such faults with short segments unfortunately so the tension between type-1 and type-3 rejections is very painful.

## The New Solution

Instead of relaxing the *close to* check for the upteenth time, I have made a modification to the line sorting algorithm. It now checks if the faults form a line, and if they don't it performs a transitive reduction and tries again. If it still fails the second time, an error is thrown. In the earlier example case, The graph starting `1 -> [2, 3], 2 -> 3` is reduced to `1 -> 2, 2 -> 3` and then the fault is then successfully constructed on the second pass. I don't believe this will introduce any errors where we accept invalid faults, but just in case I've added a warning so that the user knows to check the fault just in-case.