### PR TITLE
Add fault trace properties

### DIFF
--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -1388,7 +1388,10 @@ def simplify_fault(fault: Fault, length_tolerance: float) -> Fault:
 
     while len(planes) > 1:
         lengths = [plane.length for plane in planes]
-        if all(length >= length_tolerance for length in lengths):
+        if all(
+            length > length_tolerance or np.isclose(length, length_tolerance)
+            for length in lengths
+        ):
             break
 
         min_length_index = np.argmin(lengths)

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -422,6 +422,16 @@ class Plane:
         return shapely.Polygon(self.bounds)
 
     @property
+    def trace(self) -> np.ndarray:  # numpydoc ignore=RT01
+        """np.ndarray: The trace of the fault plane on the surface."""
+        return self.bounds[:2]
+
+    @property
+    def trace_geometry(self) -> shapely.LineString:  # numpydoc ignore=RT01
+        """shapely.LineString: The trace of the fault plane on the surface."""
+        return shapely.LineString(self.trace)
+
+    @property
     def geojson(self) -> dict:  # numpydoc ignore=RT01
         """dict: A GeoJSON representation of the fault."""
         return shapely.to_geojson(
@@ -1099,6 +1109,16 @@ class Fault:
         return shapely.normalize(
             shapely.union_all([plane.geometry for plane in self.planes])
         )
+
+    @property
+    def trace(self) -> np.ndarray:  # numpydoc ignore=RT01
+        """np.ndarray: The trace of the fault plane on the surface."""
+        return np.vstack([plane.trace for plane in self.planes])
+
+    @property
+    def trace_geometry(self) -> shapely.LineString:  # numpydoc ignore=RT01
+        """shapely.LineString: The trace of the fault plane on the surface."""
+        return shapely.LineString(self.trace)
 
     def wgs_depth_coordinates_to_fault_coordinates(
         self, global_coordinates: np.ndarray

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -432,6 +432,10 @@ def test_plane_from_trace(data: tuple):
         plane.projected_width / np.cos(np.radians(plane.dip)), abs=1e-6
     )
     assert pytest.approx(plane.length_m, abs=1e-3) == length
+    assert shapely.get_coordinates(
+        plane.trace_geometry, include_z=True
+    ) == pytest.approx(plane.bounds[:2])
+
     if plane.dip == 90:
         assert shapely.get_coordinates(plane.geometry, include_z=True) == pytest.approx(
             plane.bounds[:2]
@@ -885,6 +889,9 @@ def test_fault_construction(fault: Fault):
     assert np.isclose(fault.area(), np.sum([plane.area for plane in fault.planes]))
     assert fault.geometry.equals(
         shapely.union_all([plane.geometry for plane in fault.planes])
+    )
+    assert fault.trace_geometry.equals(
+        shapely.union_all([plane.trace_geometry for plane in fault.planes])
     )
     assert np.allclose(
         fault.wgs_depth_coordinates_to_fault_coordinates(fault.centroid),

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1205,7 +1205,9 @@ def test_simplify_fault(fault: Fault):
 
     if not consecutive_small_planes:
         assert len(simplified_fault.planes) == sum(
-            1 for plane in fault.planes if plane.length >= tolerance
+            1
+            for plane in fault.planes
+            if plane.length > tolerance or np.isclose(plane.length, tolerance)
         )
 
     # Check that the simplified fault is similar to the original fault


### PR DESCRIPTION
This PR adds fault trace properties to the `Plane` and `Fault` classes. Mostly for visualisation purposes, but also useful for other calculations.