### PR TITLE
Fix the `rake_type` function

### DIFF
--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -47,7 +47,7 @@ def rake_type(rake: float) -> RakeType:
     RakeType
         Type of rake of the fault.
     """
-    if -30 <= rake <= 30 or 150 <= rake <= 210:
+    if -30 <= rake <= 30 or 150 <= rake <= 210 or -180 <= rake <= -150:
         return RakeType.STRIKE_SLIP
     elif 60 <= rake <= 120:
         return RakeType.REVERSE

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -45,21 +45,17 @@ def rake_type(rake: float) -> RakeType:
     -------
     RakeType
         Type of rake of the fault.
-
-    Raises
-    ------
-    ValueError
-        If the rake is not between -180 and 180 degrees.
     """
-    if not (-180 <= rake <= 180):
-        raise ValueError("Rake must be between -180 and 180 degrees.")
-    if -30 <= rake <= 30 or 150 <= rake <= 210 or -180 <= rake <= -150:
+    rake %= 360
+    if (
+        (0 <= rake <= 30) or (150 <= rake <= 210) or (330 <= rake < 360)
+    ):  # Use < 360 because modulo maps 360 to 0
         return RakeType.STRIKE_SLIP
     elif 60 <= rake <= 120:
         return RakeType.REVERSE
-    elif -120 <= rake <= -60:
+    elif 240 <= rake <= 300:
         return RakeType.NORMAL
-    elif -150 < rake < -120 or -60 < rake < -30:
+    elif (210 < rake < 240) or (300 < rake < 330):
         return RakeType.NORMAL_OBLIQUE
     else:
         return RakeType.REVERSE_OBLIQUE

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -16,7 +16,6 @@ class RakeType(Enum):
     STRIKE_SLIP = auto()
     REVERSE_OBLIQUE = auto()
     NORMAL_OBLIQUE = auto()
-    UNDEFINED = auto()
 
 
 class ScalingRelation(StrEnum):
@@ -46,7 +45,14 @@ def rake_type(rake: float) -> RakeType:
     -------
     RakeType
         Type of rake of the fault.
+
+    Raises
+    ------
+    ValueError
+        If the rake is not between -180 and 180 degrees.
     """
+    if not (-180 <= rake <= 180):
+        raise ValueError("Rake must be between -180 and 180 degrees.")
     if -30 <= rake <= 30 or 150 <= rake <= 210 or -180 <= rake <= -150:
         return RakeType.STRIKE_SLIP
     elif 60 <= rake <= 120:
@@ -55,10 +61,8 @@ def rake_type(rake: float) -> RakeType:
         return RakeType.NORMAL
     elif -150 < rake < -120 or -60 < rake < -30:
         return RakeType.NORMAL_OBLIQUE
-    elif 30 < rake < 60 or 120 < rake < 150:
+    else:
         return RakeType.REVERSE_OBLIQUE
-
-    return RakeType.UNDEFINED
 
 
 def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) -> float:

--- a/tests/test_magnitude_scaling.py
+++ b/tests/test_magnitude_scaling.py
@@ -46,7 +46,6 @@ def seed(seed: int):
         (0, magnitude_scaling.RakeType.STRIKE_SLIP),
         (30, magnitude_scaling.RakeType.STRIKE_SLIP),
         (150, magnitude_scaling.RakeType.STRIKE_SLIP),
-        (210, magnitude_scaling.RakeType.STRIKE_SLIP),
         (60, magnitude_scaling.RakeType.REVERSE),
         (90, magnitude_scaling.RakeType.REVERSE),
         (120, magnitude_scaling.RakeType.REVERSE),
@@ -61,13 +60,18 @@ def seed(seed: int):
         (59, magnitude_scaling.RakeType.REVERSE_OBLIQUE),
         (121, magnitude_scaling.RakeType.REVERSE_OBLIQUE),
         (149, magnitude_scaling.RakeType.REVERSE_OBLIQUE),
-        (-200, magnitude_scaling.RakeType.UNDEFINED),
-        (250, magnitude_scaling.RakeType.UNDEFINED),
-        (999, magnitude_scaling.RakeType.UNDEFINED),
     ],
 )
 def test_rake_type(rake: float, expected: magnitude_scaling.RakeType):
     assert magnitude_scaling.rake_type(rake) == expected
+
+
+def test_invalid_rake_type():
+    """Test that an invalid rake type raises a ValueError."""
+    with pytest.raises(ValueError):
+        magnitude_scaling.rake_type(200)  # Invalid rake value
+    with pytest.raises(ValueError):
+        magnitude_scaling.rake_type(-200)  # Invalid rake value
 
 
 def relation_with_magnitude(

--- a/tests/test_magnitude_scaling.py
+++ b/tests/test_magnitude_scaling.py
@@ -46,6 +46,7 @@ def seed(seed: int):
         (0, magnitude_scaling.RakeType.STRIKE_SLIP),
         (30, magnitude_scaling.RakeType.STRIKE_SLIP),
         (150, magnitude_scaling.RakeType.STRIKE_SLIP),
+        (210, magnitude_scaling.RakeType.STRIKE_SLIP),
         (60, magnitude_scaling.RakeType.REVERSE),
         (90, magnitude_scaling.RakeType.REVERSE),
         (120, magnitude_scaling.RakeType.REVERSE),
@@ -64,14 +65,6 @@ def seed(seed: int):
 )
 def test_rake_type(rake: float, expected: magnitude_scaling.RakeType):
     assert magnitude_scaling.rake_type(rake) == expected
-
-
-def test_invalid_rake_type():
-    """Test that an invalid rake type raises a ValueError."""
-    with pytest.raises(ValueError):
-        magnitude_scaling.rake_type(200)  # Invalid rake value
-    with pytest.raises(ValueError):
-        magnitude_scaling.rake_type(-200)  # Invalid rake value
 
 
 def relation_with_magnitude(


### PR DESCRIPTION
This PR addresses [Felipe's observation](https://uceqeng.slack.com/archives/C06L1MRUQF8/p1746064429352859) that the `rake_type` function is missing a case.