### PR TITLE
Discover connected fault components

### DIFF
--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -8,7 +8,6 @@ import scipy as sp
 from scipy.cluster.hierarchy import DisjointSet
 from scipy.sparse import csr_array
 
-from qcore import geo
 from source_modelling import rupture_propagation, sources
 from source_modelling.sources import Fault, Plane
 

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -1,6 +1,7 @@
 """Utility functions for working with moment rate and moment."""
 
 import itertools
+
 import numpy as np
 import numpy.typing as npt
 import pandas as pd

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -31,7 +31,7 @@ def find_connected_faults(
     ----------
     faults : dict[str, sources.Fault]
         A dictionary mapping fault names to `sources.Fault` objects.
-    rupture_tree: tree
+    rupture_tree : tree
         The rupture causality tree, used to speed up connected fault
         calculations. Faults are only considered connected if they are joined in
         the rupture tree.

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -69,7 +69,15 @@ def find_connected_faults(
         source_distance = rupture_propagation.distance_between(
             fault_a,
             fault_b,
-            *sources.closest_points_beneath(fault_a, fault_b, min_connected_depth),
+            *sources.closest_points_beneath(
+                fault_a,
+                fault_b,
+                min(
+                    min_connected_depth,
+                    0.99 * fault_a.bottom_m,
+                    0.99 * fault_b.bottom_m,
+                ),
+            ),
         )
         if hasattr(fault_a, "planes"):
             mean_strike_a = geo.avg_wbearing(

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -22,9 +22,8 @@ def find_connected_faults(
     """Identify groups of connected faults based on proximity and dip angle.
 
     Faults are considered connected if this distance is within a specified
-    threshold, their dip angles are similar, and (optionally) their strike
-    angles are similar. A DisjointSet data structure is used to group connected
-    faults.
+    threshold and their dip angles are similar. A DisjointSet data structure is
+    used to group connected faults.
 
     Parameters
     ----------

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -14,7 +14,7 @@ from source_modelling.sources import Fault, Plane
 
 def find_connected_faults(
     faults: dict[str, Fault | Plane],
-    rupture_tree: dict[str, str | None],
+    rupture_tree: rupture_propagation.Tree,
     separation_distance: float = 2.0,
     dip_delta: float = 20.0,
     strike_delta: float | None = None,
@@ -31,6 +31,10 @@ def find_connected_faults(
     ----------
     faults : dict[str, sources.Fault]
         A dictionary mapping fault names to `sources.Fault` objects.
+    rupture_tree: tree
+        The rupture causality tree, used to speed up connected fault
+        calculations. Faults are only considered connected if they are joined in
+        the rupture tree.
     separation_distance : float, optional
         The maximum allowable distance (in kilometers) between two faults for
         them to be considered connected. Defaults to 2.0 km. This distance

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -16,6 +16,7 @@ from source_modelling.sources import Fault, Plane
 
 def find_connected_faults(
     faults: dict[str, Fault | Plane],
+    rupture_tree: dict[str, str | None],
     separation_distance: float = 2.0,
     dip_delta: float = 20.0,
     strike_delta: float | None = None,
@@ -60,11 +61,11 @@ def find_connected_faults(
     """
     fault_names = list(faults)
     fault_components = DisjointSet(fault_names)
-    for fault_a_name, fault_b_name in itertools.combinations(fault_names, r=2):
+    for fault_a_name, fault_b_name in rupture_tree.items():
+        if not fault_b_name:
+            continue
         fault_a = faults[fault_a_name]
         fault_b = faults[fault_b_name]
-        if fault_components.connected(fault_a_name, fault_b_name):
-            continue
 
         source_distance = rupture_propagation.distance_between(
             fault_a,
@@ -79,6 +80,7 @@ def find_connected_faults(
                 ),
             ),
         )
+
         if hasattr(fault_a, "planes"):
             mean_strike_a = geo.avg_wbearing(
                 [(plane.strike, plane.length) for plane in fault_a.planes]

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -24,8 +24,9 @@ def find_connected_faults(
     """Identify groups of connected faults based on proximity and dip angle.
 
     Faults are considered connected if this distance is within a specified
-    threshold and their dip angles are similar. A DisjointSet data structure
-    is used to group connected faults.
+    threshold, their dip angles are similar, and (optionally) their strike
+    angles are similar. A DisjointSet data structure is used to group connected
+    faults.
 
     Parameters
     ----------
@@ -55,6 +56,7 @@ def find_connected_faults(
         A `DisjointSet` object where each set represents a group of
         interconnected faults. The elements in the sets are the fault names
         (strings) provided in the input `faults` dictionary.
+
     """
     fault_names = list(faults)
     fault_components = DisjointSet(fault_names)
@@ -69,13 +71,13 @@ def find_connected_faults(
             fault_b,
             *sources.closest_points_beneath(fault_a, fault_b, min_connected_depth),
         )
-        if isinstance(fault_a, Fault):
+        if hasattr(fault_a, "planes"):
             mean_strike_a = geo.avg_wbearing(
                 [(plane.strike, plane.length) for plane in fault_a.planes]
             )
         else:
             mean_strike_a = fault_a.strike
-        if isinstance(fault_b, Fault):
+        if hasattr(fault_a, "planes"):
             mean_strike_b = geo.avg_wbearing(
                 [(plane.strike, plane.length) for plane in fault_b.planes]
             )

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -1,7 +1,5 @@
 """Utility functions for working with moment rate and moment."""
 
-import itertools
-
 import numpy as np
 import numpy.typing as npt
 import pandas as pd

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -74,8 +74,8 @@ def find_connected_faults(
                 fault_b,
                 min(
                     min_connected_depth,
-                    0.99 * fault_a.bottom_m,
-                    0.99 * fault_b.bottom_m,
+                    0.99 * fault_a.bottom_m / 1000,
+                    0.99 * fault_b.bottom_m / 1000,
                 ),
             ),
         )

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -16,7 +16,7 @@ from source_modelling.sources import Fault, Plane
 
 def find_connected_faults(
     faults: dict[str, Fault | Plane],
-    seperation_distance: float = 2.0,
+    separation_distance: float = 2.0,
     dip_delta: float = 20.0,
     strike_delta: float | None = None,
     min_connected_depth: float = 5.0,
@@ -85,7 +85,7 @@ def find_connected_faults(
             mean_strike_b = fault_b.strike
 
         if (
-            source_distance < seperation_distance * 1000
+            source_distance < separation_distance * 1000
             and abs(fault_a.dip - fault_b.dip) < dip_delta
             and (
                 strike_delta is None

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -17,7 +17,6 @@ def find_connected_faults(
     faults: dict[str, Fault | Plane],
     separation_distance: float = 2.0,
     dip_delta: float = 20.0,
-    strike_delta: float | None = None,
     min_connected_depth: float = 5.0,
 ) -> DisjointSet:
     """Identify groups of connected faults based on proximity and dip angle.
@@ -40,10 +39,6 @@ def find_connected_faults(
         The maximum allowable absolute difference in dip angles (in degrees)
         between two faults for them to be considered connected.
         Defaults to 20.0 degrees.
-    strike_delta : float, optional
-        The maximum allowable absolute difference in the mean strike angles (in degrees)
-        between two faults for them to be considered connected. If None, no
-        strike comparison is made. Defaults to None.
     min_connected_depth : float, optional
         The minimum depth (in kilometres)
         below which the closest points between faults are determined for the
@@ -79,26 +74,9 @@ def find_connected_faults(
             ),
         )
 
-        if hasattr(fault_a, "planes"):
-            mean_strike_a = geo.avg_wbearing(
-                [(plane.strike, plane.length) for plane in fault_a.planes]
-            )
-        else:
-            mean_strike_a = fault_a.strike
-        if hasattr(fault_b, "planes"):
-            mean_strike_b = geo.avg_wbearing(
-                [(plane.strike, plane.length) for plane in fault_b.planes]
-            )
-        else:
-            mean_strike_b = fault_b.strike
-
         if (
             source_distance < separation_distance * 1000
             and abs(fault_a.dip - fault_b.dip) < dip_delta
-            and (
-                strike_delta is None
-                or geo.angle_diff(mean_strike_a, mean_strike_b) < strike_delta
-            )
         ):
             fault_components.merge(fault_a_name, fault_b_name)
 

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -1065,7 +1065,7 @@ class Fault:
     ) -> Self:
         """Construct a fault from the trace points of the fault.
 
-        This assumes that the fault is a series of connected planes, 
+        This assumes that the fault is a series of connected planes,
         and that the planes have the same dtop, dbottom, dip and dip_dir.
 
         Parameters
@@ -1419,9 +1419,18 @@ def closest_point_between_sources(
         source_b_coordinate_bounds[2:]
     )
 
+    initial_point_a = (
+        (source_a.min_strike + source_a.max_strike) / 2,
+        (source_a.min_dip + source_a.max_dip) / 2,
+    )
+    initial_point_b = (
+        (source_b.min_strike + source_b.max_strike) / 2,
+        (source_b.min_dip + source_b.max_dip) / 2,
+    )
+
     res = sp.optimize.least_squares(
         fault_coordinate_distance,
-        np.array([1 / 2, 1 / 2, 1 / 2, 1 / 2]),
+        np.array([*initial_point_a, *initial_point_b]),
         bounds=(min_bounds, max_bounds),
         gtol=1e-5,
         ftol=1e-5,

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -1023,6 +1023,16 @@ class Fault:
                 )
 
     @property
+    def top_m(self) -> float:  # numpydoc ignore=RT01
+        """float: The top-depth of the fault"""
+        return self.planes[0].top_m
+
+    @property
+    def bottom_m(self) -> float:  # numpydoc ignore=RT01
+        """float: The bottom-depth of the fault"""
+        return self.planes[0].bottom_m
+
+    @property
     def dip(self) -> float:  # numpydoc ignore=RT01
         """float: The dip angle of the fault."""
         return self.planes[0].dip
@@ -1444,6 +1454,64 @@ def closest_point_between_sources(
             f"Optimisation failed to converge for provided sources: {res.message} with x = {res.x}"
         )
     return res.x[:2], res.x[2:]
+
+
+def closest_points_beneath(
+    source_a: Fault | Plane, source_b: Fault | Plane, min_depth: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """Find the closest points between two sources beneath a minimum depth.
+
+    Parameters
+    ----------
+    source_a : fault or plane
+        The first source.
+    source_b : fault or plane
+        The second source.
+    min_depth : float
+        The minimum depth to compare between the faults, in kilometres.
+
+    Returns
+    -------
+    source_a_coordinates : np.ndarray
+        The source-local coordinates of the closest point on source a.
+    source_b_coordinates : np.ndarray
+        The source-local coordinates of the closest point on source b.
+
+    Raises
+    ------
+    ValueError
+        If `min_depth` is below the bottom depth of either `source_a` or `source_b`.
+    """
+
+    min_depth *= _KM_TO_M
+
+    if min_depth > min(source_a.bottom_m, source_b.bottom_m):
+        raise ValueError(
+            "The specified minimum depth exceeds the bottom depth of at least one of the sources "
+            f"{min_depth=}m {source_a.bottom_m=}m {source_b.bottom_m=}m."
+        )
+
+    # The minimum dip coordinate is found via similar triangles.
+    dip_coordinate_a = min(
+        (min_depth - source_a.planes[0].top_m)
+        / (source_a.planes[0].bottom_m - source_a.planes[0].top_m),
+        0.99,
+    )
+    dip_coordinate_b = min(
+        (min_depth - source_b.planes[0].top_m)
+        / (source_b.planes[0].bottom_m - source_b.planes[0].top_m),
+        0.99,
+    )
+
+    source_a_coordinate_bounds = CoordinateBounds(
+        min_strike=0, max_strike=1, min_dip=dip_coordinate_a, max_dip=1
+    )
+    source_b_coordinate_bounds = CoordinateBounds(
+        min_strike=0, max_strike=1, min_dip=dip_coordinate_b, max_dip=1
+    )
+    return closest_point_between_sources(
+        source_a, source_b, source_a_coordinate_bounds, source_b_coordinate_bounds
+    )
 
 
 def absorb_planes(plane: Plane, other: Plane) -> Plane:

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -1492,14 +1492,16 @@ def closest_points_beneath(
         )
 
     # The minimum dip coordinate is found via similar triangles.
-    dip_coordinate_a = min(
+    dip_coordinate_a = np.clip(
         (min_depth - source_a.planes[0].top_m)
         / (source_a.planes[0].bottom_m - source_a.planes[0].top_m),
+        0,
         0.99,
     )
-    dip_coordinate_b = min(
+    dip_coordinate_b = np.clip(
         (min_depth - source_b.planes[0].top_m)
         / (source_b.planes[0].bottom_m - source_b.planes[0].top_m),
+        0,
         0.99,
     )
 

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -1485,7 +1485,7 @@ def closest_points_beneath(
 
     min_depth *= _KM_TO_M
 
-    if min_depth > min(source_a.bottom_m, source_b.bottom_m):
+    if min_depth >= min(source_a.bottom_m, source_b.bottom_m):
         raise ValueError(
             "The specified minimum depth exceeds the bottom depth of at least one of the sources "
             f"{min_depth=}m {source_a.bottom_m=}m {source_b.bottom_m=}m."

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -1420,12 +1420,14 @@ def closest_point_between_sources(
     )
 
     initial_point_a = (
-        (source_a.min_strike + source_a.max_strike) / 2,
-        (source_a.min_dip + source_a.max_dip) / 2,
+        (source_a_coordinate_bounds.min_strike + source_a_coordinate_bounds.max_strike)
+        / 2,
+        (source_a_coordinate_bounds.min_dip + source_a_coordinate_bounds.max_dip) / 2,
     )
     initial_point_b = (
-        (source_b.min_strike + source_b.max_strike) / 2,
-        (source_b.min_dip + source_b.max_dip) / 2,
+        (source_b_coordinate_bounds.min_strike + source_b_coordinate_bounds.max_strike)
+        / 2,
+        (source_b_coordinate_bounds.min_dip + source_b_coordinate_bounds.max_dip) / 2,
     )
 
     res = sp.optimize.least_squares(

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, create_autospec
+from unittest.mock import create_autospec, patch
 
 import numpy as np
 import pytest
@@ -8,7 +8,7 @@ from hypothesis import strategies as st
 from hypothesis.extra import numpy as nst
 
 from source_modelling import moment
-from source_modelling.sources import Plane, Fault
+from source_modelling.sources import Fault, Plane
 
 
 @given(

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -113,5 +113,7 @@ def test_find_connected_faults(
 
         faults = {"A": fault1, "B": fault2}
 
-        ds = moment.find_connected_faults(faults, strike_delta=strike_delta)
+        ds = moment.find_connected_faults(
+            faults, {"A": None, "B": "A"}, strike_delta=strike_delta
+        )
         assert ds.connected("A", "B") == expected_connected

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch, create_autospec
+
 import numpy as np
 import pytest
 import scipy as sp
@@ -6,6 +8,7 @@ from hypothesis import strategies as st
 from hypothesis.extra import numpy as nst
 
 from source_modelling import moment
+from source_modelling.sources import Plane, Fault
 
 
 @given(
@@ -31,7 +34,9 @@ def test_moment_rate_from_slip_properties(slip_function: np.ndarray, dt: float):
     )
     assert (moment_rate["moment_rate"] >= 0).all()
     assert len(moment_rate) == nt
-    avg_displacement = np.mean(sp.integrate.trapezoid(slip_function, dx=dt, axis=1)) / 1e6
+    avg_displacement = (
+        np.mean(sp.integrate.trapezoid(slip_function, dx=dt, axis=1)) / 1e6
+    )
     cumulative_moment = moment.moment_over_time_from_moment_rate(moment_rate)
     assert moment.MU * np.sum(patch_areas) * avg_displacement == pytest.approx(
         cumulative_moment["moment"].iloc[-1]
@@ -49,3 +54,58 @@ def test_moment_to_magnitude():
     assert moment.moment_to_magnitude(2.82e20) == pytest.approx(7.6, abs=5e-02)
     # Kaikoura FSP Hayes 2017
     assert moment.moment_to_magnitude(8.96e20) == pytest.approx(7.89, abs=5e-02)
+
+
+# The following test involves some patching to make it feasible to test properly.
+
+
+@pytest.mark.parametrize(
+    "dip_a, dip_b, strike_a, strike_b, distance, strike_delta, expected_connected",
+    [
+        (30, 32, 90, 92, 1.0, None, True),
+        (30, 60, 90, 92, 1.0, None, False),
+        (30, 32, 90, 150, 1.0, 10, False),
+        (30, 32, 90, 150, 1.0, None, True),
+        (30, 32, 90, 92, 3.0, None, False),
+    ],
+)
+def test_find_connected_faults(
+    dip_a: float,
+    dip_b: float,
+    strike_a: float,
+    strike_b: float,
+    distance: float,
+    strike_delta: float | None,
+    expected_connected: bool,
+):
+    with (
+        patch(
+            "source_modelling.rupture_propagation.distance_between",
+            return_value=distance * 1000,
+        ),
+        patch(
+            "source_modelling.sources.closest_points_beneath", return_value=("a", "b")
+        ),
+    ):
+        # Create Plane mocks
+        plane1 = create_autospec(Plane, instance=True)
+        plane1.strike = strike_a
+        plane1.length = 10
+
+        plane2 = create_autospec(Plane, instance=True)
+        plane2.strike = strike_b
+        plane2.length = 10
+
+        # Create Fault mocks
+        fault1 = create_autospec(Fault, instance=True)
+        fault1.dip = dip_a
+        fault1.planes = [plane1]
+
+        fault2 = create_autospec(Fault, instance=True)
+        fault2.dip = dip_b
+        fault2.planes = [plane2]
+
+        faults = {"A": fault1, "B": fault2}
+
+        ds = moment.find_connected_faults(faults, strike_delta=strike_delta)
+        assert ds.connected("A", "B") == expected_connected

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -60,13 +60,12 @@ def test_moment_to_magnitude():
 
 
 @pytest.mark.parametrize(
-    "dip_a, dip_b, strike_a, strike_b, distance, strike_delta, expected_connected",
+    "dip_a, dip_b, strike_a, strike_b, distance, expected_connected",
     [
-        (30, 32, 90, 92, 1.0, None, True),
-        (30, 60, 90, 92, 1.0, None, False),
-        (30, 32, 90, 150, 1.0, 10, False),
-        (30, 32, 90, 150, 1.0, None, True),
-        (30, 32, 90, 92, 3.0, None, False),
+        (30, 32, 90, 92, 1.0, True),
+        (30, 60, 90, 92, 1.0, False),
+        (30, 32, 90, 150, 1.0, True),
+        (30, 32, 90, 92, 3.0, False),
     ],
 )
 def test_find_connected_faults(
@@ -75,7 +74,6 @@ def test_find_connected_faults(
     strike_a: float,
     strike_b: float,
     distance: float,
-    strike_delta: float | None,
     expected_connected: bool,
 ):
     with (
@@ -113,5 +111,7 @@ def test_find_connected_faults(
 
         faults = {"A": fault1, "B": fault2}
 
-        ds = moment.find_connected_faults(faults, strike_delta=strike_delta)
+        ds = moment.find_connected_faults(
+            faults,
+        )
         assert ds.connected("A", "B") == expected_connected

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -113,7 +113,5 @@ def test_find_connected_faults(
 
         faults = {"A": fault1, "B": fault2}
 
-        ds = moment.find_connected_faults(
-            faults, {"A": None, "B": "A"}, strike_delta=strike_delta
-        )
+        ds = moment.find_connected_faults(faults, strike_delta=strike_delta)
         assert ds.connected("A", "B") == expected_connected

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -100,10 +100,16 @@ def test_find_connected_faults(
         fault1 = create_autospec(Fault, instance=True)
         fault1.dip = dip_a
         fault1.planes = [plane1]
+        fault1.bottom_m = (
+            10000.0  # closest points beneath is mocked out so it doesn't matter
+        )
 
         fault2 = create_autospec(Fault, instance=True)
         fault2.dip = dip_b
         fault2.planes = [plane2]
+        fault2.bottom_m = (
+            10000.0  # closest points beneath is mocked out so it doesn't matter
+        )
 
         faults = {"A": fault1, "B": fault2}
 


### PR DESCRIPTION
This functionality is required for multi-segment ruptures. It allows a user to group a set of faults together into connected components depending on different criteria:

- Based on `dip` angle difference: faults are only considered connected if they at least have close enough dip.
- Based on `strike` angle difference: faults are only considered connected if they at least have close enough strike.
- Based on physical distance: faults are only considered close if connected are physically close. This distance is measured below a fixed depth (using a new optimisation function), which ensures that faults that touch at the surface are not given a distance of 0km automatically.

New tests are implemented. I have mocked out parts of the function to make it easier to test them.