### PR TITLE
Correct plane area calculation for non-square planar segments

### DIFF
--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -355,7 +355,15 @@ class Plane:
     @property
     def area(self) -> float:  # numpydoc ignore=RT01
         """float: The area of the plane (in km^2)."""
-        return self.length * self.width
+        return (
+            0.5
+            * np.linalg.norm(
+                np.cross(
+                    self.bounds[2] - self.bounds[0], self.bounds[1] - self.bounds[3]
+                )
+            )
+            / 1000.0**2
+        )
 
     @property
     def projected_width_m(self) -> float:  # numpydoc ignore=RT01
@@ -1125,7 +1133,7 @@ class Fault:
         float
             The area of the fault.
         """
-        return self.width * np.sum(self.lengths)
+        return sum(plane.area for plane in self.planes)
 
     @property
     def lengths(self) -> np.ndarray:  # numpydoc ignore=RT01

--- a/source_modelling/sources.py
+++ b/source_modelling/sources.py
@@ -362,7 +362,7 @@ class Plane:
                     self.bounds[2] - self.bounds[0], self.bounds[1] - self.bounds[3]
                 )
             )
-            / 1000.0**2
+            / _KM_TO_M**2
         )
 
     @property


### PR DESCRIPTION
Previously the could simply calculated area as $lw$, however, for highly non-rectangular fault segments, this is incorrect. Instead it should be calculated as the area of the parallelogram formed by the plane. The formula for this would be $lw\sin(\delta)$ where $\delta$ is the difference between strike and dip direction. In the usual dip direction is strike + 90 case we recover the original formula. I don't anticipate this correction making a very large difference, maybe a few percent or so on the grandest scales.