### PR TITLE
Add HDF5 output function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
    "parse",
    "shapely",
    "scipy",
+   "xarray[io]",
    "networkx"
 ]
 


### PR DESCRIPTION
Adds methods to read/write an SRF to HDF5. Is intended to replace my C code `srf2hdf5` because the SRF parsing is actually faster in the python version thanks to the highly optimised Rust code.

Because the SRF parser completely parses the SRF you get, in addition to what the C code used to parse, all the headers, and the full slip array. And of course the new code is tested where the old code was not. 