### PR TITLE
Add newline between first and last 8 point values

### DIFF
--- a/source_modelling/srf_parser/src/lib.rs
+++ b/source_modelling/srf_parser/src/lib.rs
@@ -176,7 +176,7 @@ fn write_srf_points(
         buffered_writer
             .write_all(b"\n")
             .or_else(marshall_os_error)?;
-        for v in row.iter().drop(summary_length) {
+        for v in row.iter().skip(summary_length) {
             let slice = lexical_core::write(*v, &mut buffer);
             buffered_writer
                 .write_all(slice)

--- a/source_modelling/srf_parser/src/lib.rs
+++ b/source_modelling/srf_parser/src/lib.rs
@@ -46,23 +46,19 @@ fn marshall_value_error<T>(e: lexical_core::Error) -> PyResult<T> {
     Err(PyErr::new::<PyValueError, _>(e.to_string()))
 }
 
-fn space_index(data: &[u8]) -> Result<usize, lexical_core::Error> {
-    let nonwhitespace = data
-        .iter()
-        .enumerate()
-        .find(|&(_, &x)| !x.is_ascii_whitespace())
-        .map(|(idx, _)| idx);
-    match nonwhitespace {
-        Some(x) => Ok(x),
-        _ => Err(lexical_core::Error::InvalidDigit(0)),
+fn space_index(data: &[u8]) -> usize {
+    let mut index = 0;
+    while index < data.len() && data[index].is_ascii_whitespace() {
+        index += 1;
     }
+    index
 }
 
 fn parse_value<T: lexical_core::FromLexical>(
     data: &[u8],
     index: &mut usize,
 ) -> Result<T, lexical_core::Error> {
-    *index += space_index(&data[*index..])?;
+    *index += space_index(&data[*index..]);
     let (val, read) = lexical_core::parse_partial(&data[*index..])?;
     *index += read;
     Ok(val)
@@ -176,7 +172,11 @@ fn write_srf_points(
         buffered_writer
             .write_all(b"\n")
             .or_else(marshall_os_error)?;
-        for v in row.iter().skip(summary_length) {
+        for v in row
+            .iter()
+            .skip(summary_length)
+            .take(row.len() - 1 - summary_length)
+        {
             let slice = lexical_core::write(*v, &mut buffer);
             buffered_writer
                 .write_all(slice)


### PR DESCRIPTION
Small change, fixes SRF generation by adding a newline between the first 8 and last values of each point. This is required because tools like `srf2stoch` grab the first 8 values in one line and then discard the leftovers and get the next values on a newline.

The current behaviour is to produce points like this

```
# lon     lat        dep     stk   dip  area        tinit  dt   rake slip1    nt1 ...
172.15625 -43.478912 1.44506 150.0 54.0 100102000.0 6.4191 0.05 54.0 135.8391 14 0.0 0 0.0 0
# slip time
0.0 554.722 897.755 422.767 168.633 154.696 136.741 115.893 93.4622 70.8549 49.4901 30.7083 15.6881 5.37197
```

but we really want to format it like this

```
# lon     lat        dep     stk   dip  area        tinit  dt
172.15625 -43.478912 1.44506 150.0 54.0 100102000.0 6.4191 0.05
# rake slip1  nt1 ...
54.0 135.8391 14 0.0 0 0.0 0
0.0 554.722 897.755 422.767 168.633 154.696 136.741 115.893 93.4622 70.8549 49.4901 30.7083 15.6881 5.37197
```