### PR TITLE
Distinguish BoldM and Mw magnitude conventions via NewType

### DIFF
--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -1,11 +1,15 @@
 """Magnitude scaling relationships for fault dimensions."""
 
 import functools
+import typing
 import warnings
 from enum import Enum, StrEnum, auto
 
 import numpy as np
 import scipy as sp
+
+BoldM = typing.NewType("BoldM", float)
+Mw = typing.NewType("Mw", float)
 
 
 class RakeType(Enum):
@@ -61,7 +65,7 @@ def rake_type(rake: float) -> RakeType:
         return RakeType.REVERSE_OBLIQUE
 
 
-def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) -> float:
+def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) -> Mw:
     """Convert area to magnitude using the leonard scaling relationship [0]_.
 
     Parameters
@@ -76,7 +80,7 @@ def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) ->
 
     Returns
     -------
-    float
+    Mw
         Moment magnitude of the fault.
 
     Notes
@@ -106,13 +110,13 @@ def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) ->
 
 
 def leonard_magnitude_to_area(
-    magnitude: float, rake: float, random: bool = False
+    magnitude: Mw, rake: float, random: bool = False
 ) -> float:
     """Convert magnitude to area using the Leonard scaling relationship [0]_.
 
     Parameters
     ----------
-    magnitude : float
+    magnitude : Mw
         Moment magnitude of the fault.
     rake : float
         Rake of the fault (degrees).
@@ -150,7 +154,7 @@ def leonard_magnitude_to_area(
 
 
 def leonard_magnitude_to_length(
-    magnitude: float,
+    magnitude: Mw,
     rake: float,
     random: bool = False,
 ) -> float:
@@ -158,7 +162,7 @@ def leonard_magnitude_to_length(
 
     Parameters
     ----------
-    magnitude : float
+    magnitude : Mw
             Moment magnitude of the fault.
     rake : float
             Rake of the fault (degrees).
@@ -203,7 +207,7 @@ def leonard_magnitude_to_length(
 
 
 def leonard_magnitude_to_width(
-    magnitude: float,
+    magnitude: Mw,
     rake: float,
     random: bool = False,
 ) -> float:
@@ -211,7 +215,7 @@ def leonard_magnitude_to_width(
 
     Parameters
     ----------
-    magnitude : float
+    magnitude : Mw
             Moment magnitude of the fault.
     rake : float
             Rake of the fault (degrees).
@@ -257,7 +261,7 @@ def leonard_magnitude_to_width(
 
 
 def leonard_magnitude_to_length_width(
-    magnitude: float,
+    magnitude: Mw,
     rake: float,
     random: bool = False,
 ) -> tuple[float, float]:
@@ -265,7 +269,7 @@ def leonard_magnitude_to_length_width(
 
     Parameters
     ----------
-    magnitude : float
+    magnitude : Mw
         Moment magnitude of the fault.
     rake : float
         Rake of the fault (degrees).
@@ -314,7 +318,7 @@ def area_aspect_ratio_to_length_width(
     return length, width
 
 
-def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> float:
+def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> BoldM:
     """Convert area to magnitude using the Contreras scaling relationship [0]_.
 
     Parameters
@@ -327,7 +331,7 @@ def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> 
 
     Returns
     -------
-    float
+    BoldM
         Moment magnitude of the fault.
 
     Warns
@@ -359,13 +363,13 @@ def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> 
 
 
 def contreras_interface_magnitude_to_area(
-    magnitude: float, random: bool = False
+    magnitude: BoldM, random: bool = False
 ) -> float:
     """Convert magnitude to area using the Contreras scaling relationship [0]_.
 
     Parameters
     ----------
-    magnitude : float
+    magnitude : BoldM
         Moment magnitude of the fault.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
@@ -405,13 +409,13 @@ def contreras_interface_magnitude_to_area(
 
 
 def contreras_interface_magnitude_to_aspect_ratio(
-    magnitude: float, random: bool = False
+    magnitude: BoldM, random: bool = False
 ) -> float:
     """Convert magnitude to aspect ratio (L/W) using the Contreras scaling relationship [0]_.
 
     Parameters
     ----------
-    magnitude : float
+    magnitude : BoldM
         Moment magnitude of the fault.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
@@ -449,13 +453,13 @@ def contreras_interface_magnitude_to_aspect_ratio(
 
 
 def contreras_interface_magnitude_to_length_width(
-    magnitude: float, random: bool = False
+    magnitude: BoldM, random: bool = False
 ) -> tuple[float, float]:
     """Convert magnitude to length and width using the Contreras scaling relationship [0]_.
 
     Parameters
     ----------
-    magnitude : float
+    magnitude : BoldM
             Moment magnitude of the fault.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
@@ -476,7 +480,7 @@ def contreras_interface_magnitude_to_length_width(
     return area_aspect_ratio_to_length_width(area, aspect_ratio)
 
 
-def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> float:
+def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> BoldM:
     """Convert area to magnitude using the Strasser scaling relationship [0]_.
 
     Parameters
@@ -489,13 +493,19 @@ def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> float:
 
     Returns
     -------
-    float
-        Moment magnitude of the fault.
+    BoldM
+        Moment magnitude of the fault's rupture.
 
     Warns
     -----
     UserWarning
         If the area is not between the minimum and maximum area of the Strasser model, estimated at 130km^2 and 5212km^2.
+
+    Notes
+    -----
+    The moment magnitude convention is not specified in [0]_, so we assume
+    BoldM for consistency with [1]_, which recommends this relationship for
+    intraslab events.
 
     References
     ----------
@@ -503,6 +513,8 @@ def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> float:
            "Scaling of the source dimensions of interface and intraslab
            subduction-zone earthquakes with moment magnitude." Seismological
            Research Letters 81.6 (2010): 941-950.
+    .. [1] Contreras, Victor, et al. "NGA-Sub source and path database."
+           Earthquake Spectra 38.2 (2022): 799-840.
     """
 
     # lower bound and upper bound for the area are estimated from the minimum and maximum magnitude of the Strasser model.
@@ -521,13 +533,13 @@ def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> float:
     return a + sigma_a + (b + sigma_b) * np.log10(area)
 
 
-def strasser_slab_magnitude_to_area(magnitude: float, random: bool = False) -> float:
+def strasser_slab_magnitude_to_area(magnitude: BoldM, random: bool = False) -> float:
     """Convert magnitude to area using the Strasser scaling relationship [0]_.
 
     Parameters
     ----------
-    magnitude : float
-        Moment magnitude of the fault.
+    magnitude : BoldM
+        Moment magnitude of the fault's rupture.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
         paper, otherwise use the mean values. Default is False.
@@ -543,12 +555,20 @@ def strasser_slab_magnitude_to_area(magnitude: float, random: bool = False) -> f
         If the magnitude is less than the minimum magnitude of 5.9 or
         larger than the maximum magnitude of 7.8.
 
+    Notes
+    -----
+    The moment magnitude convention is not specified in [0]_, so we assume
+    BoldM for consistency with [1]_, which recommends this relationship for
+    intraslab events.
+
     References
     ----------
     .. [0] Strasser, Fleur O., M. C. Arango, and Julian J. Bommer.
            "Scaling of the source dimensions of interface and intraslab
            subduction-zone earthquakes with moment magnitude." Seismological
            Research Letters 81.6 (2010): 941-950.
+    .. [1] Contreras, Victor, et al. "NGA-Sub source and path database."
+           Earthquake Spectra 38.2 (2022): 799-840.
     """
     if not (5.9 <= magnitude <= 7.8):
         warnings.warn(
@@ -562,13 +582,13 @@ def strasser_slab_magnitude_to_area(magnitude: float, random: bool = False) -> f
 
 
 def contreras_slab_magnitude_to_aspect_ratio(
-    magnitude: float, random: bool = False
+    magnitude: BoldM, random: bool = False
 ) -> float:
     """Convert magnitude to aspect ratio (L/W) using the Contreras scaling relationship [0]_.
 
     Parameters
     ----------
-    magnitude : float
+    magnitude : BoldM
         Moment magnitude of the fault.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
@@ -609,13 +629,13 @@ def contreras_slab_magnitude_to_aspect_ratio(
 
 
 def contreras_slab_magnitude_to_length_width(
-    magnitude: float, random: bool = False
+    magnitude: BoldM, random: bool = False
 ) -> tuple[float, float]:
     """Convert magnitude to length and width using the Contreras scaling relationship [0]_.
 
     Parameters
     ----------
-    magnitude : float
+    magnitude : BoldM
         Moment magnitude of the fault.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
@@ -640,7 +660,7 @@ def contreras_slab_magnitude_to_length_width(
 
 def magnitude_to_length_width(
     scaling_relation: ScalingRelation,
-    magnitude: float,
+    magnitude: BoldM | Mw,
     rake: float | None = None,
     random: bool = False,
 ) -> tuple[float, float]:
@@ -650,8 +670,8 @@ def magnitude_to_length_width(
     ----------
     scaling_relation : ScalingRelation
         Scaling relation to use.
-    magnitude : float
-        Moment magnitude of the fault.
+    magnitude : BoldM | Mw
+        Moment magnitude of the fault's rupture.
     rake : float, optional
         Rake of the fault (degrees). Required for Leonard scaling.
     random : bool, optional
@@ -680,12 +700,15 @@ def magnitude_to_length_width(
             contreras_slab_magnitude_to_length_width, random=random
         ),
     }
-    return scaling_relations_map[scaling_relation](magnitude)
+    # The dispatched callable is a union of partials expecting either Mw or BoldM,
+    # so ty can't see that the scaling_relation key already determines which
+    # convention `magnitude` should be treated as.
+    return scaling_relations_map[scaling_relation](magnitude)  # ty: ignore[invalid-argument-type]
 
 
 def magnitude_to_area(
     scaling_relation: ScalingRelation,
-    magnitude: float,
+    magnitude: BoldM | Mw,
     rake: float | None = None,
     random: bool = False,
 ) -> float:
@@ -695,8 +718,8 @@ def magnitude_to_area(
     ----------
     scaling_relation : ScalingRelation
         Scaling relation to use.
-    magnitude : float
-        Moment magnitude of the fault.
+    magnitude : BoldM | Mw
+        Moment magnitude of the fault's rupture.
     rake : float, optional
         Rake of the fault (degrees). Required for Leonard scaling.
     random : bool, optional
@@ -729,7 +752,8 @@ def magnitude_to_area(
             strasser_slab_magnitude_to_area, random=random
         ),
     }
-    return scaling_relations_map[scaling_relation](magnitude)
+    # See note in `magnitude_to_length_width` about why this is ignored.
+    return scaling_relations_map[scaling_relation](magnitude)  # ty: ignore[invalid-argument-type]
 
 
 def area_to_magnitude(
@@ -737,7 +761,7 @@ def area_to_magnitude(
     area: float,
     rake: float | None = None,
     random: bool = False,
-) -> float:
+) -> BoldM | Mw:
     """Convert area to magnitude using a scaling relationship.
 
     Parameters
@@ -754,8 +778,8 @@ def area_to_magnitude(
 
     Returns
     -------
-    float
-        Moment magnitude of the fault estimated by the scaling relation.
+    BoldM | Mw
+        Moment magnitude of the fault's rupture estimated by the scaling relation.
     """
     if scaling_relation == ScalingRelation.LEONARD2014 and rake is None:
         raise ValueError("Rake must be specified for Leonard scaling.")

--- a/source_modelling/magnitude_scaling.py
+++ b/source_modelling/magnitude_scaling.py
@@ -71,7 +71,7 @@ def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) ->
     Parameters
     ----------
     area : float
-        Area of the fault (km^2).
+        Area of the fault rupture (km^2).
     rake : float
         Rake of the fault (degrees).
     random : bool, optional
@@ -81,7 +81,7 @@ def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) ->
     Returns
     -------
     Mw
-        Moment magnitude of the fault.
+        Moment magnitude of the fault rupture.
 
     Notes
     -----
@@ -104,8 +104,8 @@ def leonard_area_to_magnitude(area: float, rake: float, random: bool = False) ->
         )
 
     # Leonard quotes assymetric uncertainties for the other rake types.
-    return np.log10(area) + (
-        sp.stats.norm(loc=4.03, scale=0.3).rvs() if random else 4.0
+    return Mw(
+        np.log10(area) + (sp.stats.norm(loc=4.03, scale=0.3).rvs() if random else 4.0)
     )
 
 
@@ -117,7 +117,7 @@ def leonard_magnitude_to_area(
     Parameters
     ----------
     magnitude : Mw
-        Moment magnitude of the fault.
+        Moment magnitude of the fault rupture.
     rake : float
         Rake of the fault (degrees).
     random : bool, optional
@@ -127,7 +127,7 @@ def leonard_magnitude_to_area(
     Returns
     -------
     float
-        Area of the fault. (km^2)
+        Area of the fault rupture. (km^2)
 
     Notes
     -----
@@ -163,7 +163,7 @@ def leonard_magnitude_to_length(
     Parameters
     ----------
     magnitude : Mw
-            Moment magnitude of the fault.
+            Moment magnitude of the fault rupture.
     rake : float
             Rake of the fault (degrees).
     random : bool, optional
@@ -173,7 +173,7 @@ def leonard_magnitude_to_length(
     Returns
     -------
     float
-            Length of the fault. (km)
+            Length of the fault rupture. (km)
 
     References
     ----------
@@ -216,7 +216,7 @@ def leonard_magnitude_to_width(
     Parameters
     ----------
     magnitude : Mw
-            Moment magnitude of the fault.
+            Moment magnitude of the fault rupture.
     rake : float
             Rake of the fault (degrees).
     random : bool, optional
@@ -226,7 +226,7 @@ def leonard_magnitude_to_width(
     Returns
     -------
     float
-            Width of the fault. (km)
+            Width of the fault rupture. (km)
 
     Warns
     -----
@@ -270,7 +270,7 @@ def leonard_magnitude_to_length_width(
     Parameters
     ----------
     magnitude : Mw
-        Moment magnitude of the fault.
+        Moment magnitude of the fault rupture.
     rake : float
         Rake of the fault (degrees).
     random : bool, optional
@@ -280,7 +280,7 @@ def leonard_magnitude_to_length_width(
     Returns
     -------
     tuple[float, float]
-        Length and width of the fault.
+        Length and width of the fault rupture.
 
     References
     ----------
@@ -324,7 +324,7 @@ def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> 
     Parameters
     ----------
     area : float
-        Area of the fault (km^2).
+        Area of the fault rupture (km^2).
     random : bool, optional
         If True, sample parameters according to uncertainties in the
         paper, otherwise use the mean values. Default is False.
@@ -332,7 +332,7 @@ def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> 
     Returns
     -------
     BoldM
-        Moment magnitude of the fault.
+        Moment magnitude of the fault rupture.
 
     Warns
     -----
@@ -359,7 +359,7 @@ def contreras_interface_area_to_magnitude(area: float, random: bool = False) -> 
     sigma_a = sp.stats.norm(loc=0, scale=0.73).rvs() if random else 0
     a_1 = -8.890
     a_2 = np.log(10)
-    return 1 / a_2 * (np.log(area) - a_1 - sigma_a)
+    return BoldM(1 / a_2 * (np.log(area) - a_1 - sigma_a))
 
 
 def contreras_interface_magnitude_to_area(
@@ -370,7 +370,7 @@ def contreras_interface_magnitude_to_area(
     Parameters
     ----------
     magnitude : BoldM
-        Moment magnitude of the fault.
+        Moment magnitude of the fault rupture.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
         paper, otherwise use the mean values. Default is False.
@@ -378,7 +378,7 @@ def contreras_interface_magnitude_to_area(
     Returns
     -------
     float
-        Area of the fault. (km^2)
+        Area of the fault rupture. (km^2)
 
     Warns
     -----
@@ -416,7 +416,7 @@ def contreras_interface_magnitude_to_aspect_ratio(
     Parameters
     ----------
     magnitude : BoldM
-        Moment magnitude of the fault.
+        Moment magnitude of the fault rupture.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
         paper, otherwise use the mean values. Default is False.
@@ -460,7 +460,7 @@ def contreras_interface_magnitude_to_length_width(
     Parameters
     ----------
     magnitude : BoldM
-            Moment magnitude of the fault.
+            Moment magnitude of the fault rupture.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
         paper, otherwise use the mean values. Default is False.
@@ -468,7 +468,7 @@ def contreras_interface_magnitude_to_length_width(
     Returns
     -------
     tuple[float, float]
-            Length and width of the fault.
+            Length and width of the fault rupture.
 
     References
     ----------
@@ -494,7 +494,7 @@ def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> BoldM:
     Returns
     -------
     BoldM
-        Moment magnitude of the fault's rupture.
+        Moment magnitude of the fault rupture.
 
     Warns
     -----
@@ -530,7 +530,7 @@ def strasser_slab_area_to_magnitude(area: float, random: bool = False) -> BoldM:
     sigma_a = sp.stats.norm(loc=0, scale=0.288).rvs() if random else 0
     sigma_b = sp.stats.norm(loc=0, scale=0.093).rvs() if random else 0
 
-    return a + sigma_a + (b + sigma_b) * np.log10(area)
+    return BoldM(a + sigma_a + (b + sigma_b) * np.log10(area))
 
 
 def strasser_slab_magnitude_to_area(magnitude: BoldM, random: bool = False) -> float:
@@ -539,7 +539,7 @@ def strasser_slab_magnitude_to_area(magnitude: BoldM, random: bool = False) -> f
     Parameters
     ----------
     magnitude : BoldM
-        Moment magnitude of the fault's rupture.
+        Moment magnitude of the fault rupture.
     random : bool, optional
         If True, sample parameters according to uncertainties in the
         paper, otherwise use the mean values. Default is False.
@@ -671,7 +671,7 @@ def magnitude_to_length_width(
     scaling_relation : ScalingRelation
         Scaling relation to use.
     magnitude : BoldM | Mw
-        Moment magnitude of the fault's rupture.
+        Moment magnitude of the fault rupture.
     rake : float, optional
         Rake of the fault (degrees). Required for Leonard scaling.
     random : bool, optional
@@ -719,7 +719,7 @@ def magnitude_to_area(
     scaling_relation : ScalingRelation
         Scaling relation to use.
     magnitude : BoldM | Mw
-        Moment magnitude of the fault's rupture.
+        Moment magnitude of the fault rupture.
     rake : float, optional
         Rake of the fault (degrees). Required for Leonard scaling.
     random : bool, optional
@@ -779,7 +779,7 @@ def area_to_magnitude(
     Returns
     -------
     BoldM | Mw
-        Moment magnitude of the fault's rupture estimated by the scaling relation.
+        Moment magnitude of the fault rupture estimated by the scaling relation.
     """
     if scaling_relation == ScalingRelation.LEONARD2014 and rake is None:
         raise ValueError("Rake must be specified for Leonard scaling.")

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -129,9 +129,13 @@ def moment_rate_over_time_from_slip(
 
 
 @typing.overload
-def moment_to_magnitude(moment: float, bold_m: typing.Literal[True]) -> BoldM: ...  # numpydoc ignore=GL08
+def moment_to_magnitude(
+    moment: float, bold_m: typing.Literal[True]
+) -> BoldM: ...  # numpydoc ignore=GL08
 @typing.overload
-def moment_to_magnitude(moment: float, bold_m: typing.Literal[False] = False) -> Mw: ...  # numpydoc ignore=GL08
+def moment_to_magnitude(
+    moment: float, bold_m: typing.Literal[False] = False
+) -> Mw: ...  # numpydoc ignore=GL08
 def moment_to_magnitude(moment: float, bold_m: bool = True) -> BoldM | Mw:
     """Convert moment to magnitude.
 
@@ -162,12 +166,14 @@ def moment_to_magnitude(moment: float, bold_m: bool = True) -> BoldM | Mw:
     if bold_m:
         return BoldM(2 / 3 * np.log10(moment) - EQUATION_7_COEFFICIENT)
 
-    if not bold_m:
+    else:
         return Mw(2 / 3 * np.log10(moment) - EQUATION_4_COEFFICIENT)
 
 
 @typing.overload
-def magnitude_to_moment(magnitude: BoldM, bold_m: typing.Literal[True]) -> float: ...  # numpydoc ignore=GL08
+def magnitude_to_moment(
+    magnitude: BoldM, bold_m: typing.Literal[True]
+) -> float: ...  # numpydoc ignore=GL08
 @typing.overload
 def magnitude_to_moment(
     magnitude: Mw, bold_m: typing.Literal[False] = False
@@ -192,7 +198,7 @@ def magnitude_to_moment(magnitude: BoldM | Mw, bold_m: bool = True) -> float:
 
     if bold_m:
         return 10 ** ((magnitude + EQUATION_7_COEFFICIENT) * 3 / 2)
-    if not bold_m:
+    else:
         return 10 ** ((magnitude + EQUATION_4_COEFFICIENT) * 3 / 2)
 
 

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -17,7 +17,7 @@ from source_modelling.sources import Fault, Plane
 # Moment magnitude scale coefficients for seismic moment in Nm, from
 # equations 4 and 7 of Hanks and Kanamori (1979). See the [Hanks1979] reference
 # in the `moment_to_magnitude` docstring for the full citation.
-EQUATION_4_COEFFICIENT = 6.0666  # `Mw` convention
+EQUATION_4_COEFFICIENT = 6.0667  # `Mw` convention
 EQUATION_7_COEFFICIENT = 6.0333  # `BoldM` convention
 
 

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -129,9 +129,9 @@ def moment_rate_over_time_from_slip(
 
 
 @typing.overload
-def moment_to_magnitude(moment: float, bold_m: typing.Literal[True]) -> BoldM: ...
+def moment_to_magnitude(moment: float, bold_m: typing.Literal[True]) -> BoldM: ...  # numpydoc ignore=GL08
 @typing.overload
-def moment_to_magnitude(moment: float, bold_m: typing.Literal[False] = False) -> Mw: ...
+def moment_to_magnitude(moment: float, bold_m: typing.Literal[False] = False) -> Mw: ...  # numpydoc ignore=GL08
 def moment_to_magnitude(moment: float, bold_m: bool = True) -> BoldM | Mw:
     """Convert moment to magnitude.
 
@@ -167,11 +167,11 @@ def moment_to_magnitude(moment: float, bold_m: bool = True) -> BoldM | Mw:
 
 
 @typing.overload
-def magnitude_to_moment(magnitude: BoldM, bold_m: typing.Literal[True]) -> float: ...
+def magnitude_to_moment(magnitude: BoldM, bold_m: typing.Literal[True]) -> float: ...  # numpydoc ignore=GL08
 @typing.overload
 def magnitude_to_moment(
     magnitude: Mw, bold_m: typing.Literal[False] = False
-) -> float: ...
+) -> float: ...  # numpydoc ignore=GL08
 def magnitude_to_moment(magnitude: BoldM | Mw, bold_m: bool = True) -> float:
     """Convert magnitude to moment.
 

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -151,8 +151,8 @@ def moment_to_magnitude(moment: float, bold_m: bool = False) -> Mw | BoldM:
     """
     mw = 2 / 3 * np.log10(moment) - 6.03333
     if bold_m:
-        return mw + BOLDM_MW_OFFSET
-    return mw
+        return BoldM(mw + BOLDM_MW_OFFSET)
+    return Mw(mw)
 
 
 @typing.overload

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -1,6 +1,7 @@
 """Utility functions for working with moment rate and moment."""
 
 import itertools
+import typing
 
 import numpy as np
 import numpy.typing as npt
@@ -10,7 +11,11 @@ from scipy.cluster.hierarchy import DisjointSet
 from scipy.sparse import csr_array
 
 from source_modelling import rupture_propagation, sources
+from source_modelling.magnitude_scaling import BoldM, Mw
 from source_modelling.sources import Fault, Plane
+
+# Offset between the BoldM and Mw magnitude conventions: BoldM = Mw + BOLDM_MW_OFFSET.
+BOLDM_MW_OFFSET = 0.0333
 
 
 def find_connected_faults(
@@ -120,7 +125,13 @@ def moment_rate_over_time_from_slip(
     return moment_rate_df
 
 
-def moment_to_magnitude(moment: float) -> float:
+@typing.overload
+def moment_to_magnitude(
+    moment: float, bold_m: typing.Literal[False] = False
+) -> Mw: ...
+@typing.overload
+def moment_to_magnitude(moment: float, bold_m: typing.Literal[True]) -> BoldM: ...
+def moment_to_magnitude(moment: float, bold_m: bool = False) -> Mw | BoldM:
     """Convert moment to magnitude.
 
     NOTE: the qcore mag_scaling module does not have this expression.
@@ -129,29 +140,46 @@ def moment_to_magnitude(moment: float) -> float:
     ----------
     moment : float
         The moment of the rupture in Nm.
+    bold_m : bool, optional
+        If True, return the magnitude in BoldM convention
+        (`BoldM = Mw + BOLDM_MW_OFFSET`). Default is False (Mw).
 
     Returns
     -------
-    float
-        Rupture magnitude
+    Mw | BoldM
+        Rupture magnitude in the requested convention.
     """
-    return 2 / 3 * np.log10(moment) - 6.03333
+    mw = 2 / 3 * np.log10(moment) - 6.03333
+    if bold_m:
+        return mw + BOLDM_MW_OFFSET
+    return mw
 
 
-def magnitude_to_moment(magnitude: float) -> float:
+@typing.overload
+def magnitude_to_moment(
+    magnitude: Mw, bold_m: typing.Literal[False] = False
+) -> float: ...
+@typing.overload
+def magnitude_to_moment(magnitude: BoldM, bold_m: typing.Literal[True]) -> float: ...
+def magnitude_to_moment(magnitude: Mw | BoldM, bold_m: bool = False) -> float:
     """Convert magnitude to moment.
 
     Parameters
     ----------
-    magnitude : float
-        The magnitude of the rupture.
+    magnitude : Mw | BoldM
+        The magnitude of the rupture, in the convention indicated by `bold_m`.
+    bold_m : bool, optional
+        If True, `magnitude` is interpreted as BoldM and converted to Mw
+        (`Mw = BoldM - BOLDM_MW_OFFSET`) before computing the moment.
+        Default is False (input is Mw).
 
     Returns
     -------
     float
         Rupture moment in Nm.
     """
-    return 10 ** ((magnitude + 6.03333) * 3 / 2)
+    mw = magnitude - BOLDM_MW_OFFSET if bold_m else magnitude
+    return 10 ** ((mw + 6.03333) * 3 / 2)
 
 
 def moment_over_time_from_moment_rate(moment_rate_df: pd.DataFrame) -> pd.DataFrame:

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -192,7 +192,7 @@ def magnitude_to_moment(magnitude: BoldM | Mw, bold_m: bool = True) -> float:
 
     if bold_m:
         return 10 ** ((magnitude + EQUATION_7_COEFFICIENT) * 3 / 2)
-    if not bold_m:
+    else:
         return 10 ** ((magnitude + EQUATION_4_COEFFICIENT) * 3 / 2)
 
 

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -14,8 +14,11 @@ from source_modelling import rupture_propagation, sources
 from source_modelling.magnitude_scaling import BoldM, Mw
 from source_modelling.sources import Fault, Plane
 
-# Offset between the BoldM and Mw magnitude conventions: BoldM = Mw + BOLDM_MW_OFFSET.
-BOLDM_MW_OFFSET = 0.0333
+# Moment magnitude scale coefficients for seismic moment in Nm, from
+# equations 4 and 7 of Hanks and Kanamori (1979). See the [Hanks1979] reference
+# in the `moment_to_magnitude` docstring for the full citation.
+EQUATION_4_COEFFICIENT = 6.0666  # `Mw` convention
+EQUATION_7_COEFFICIENT = 6.0333  # `BoldM` convention
 
 
 def find_connected_faults(
@@ -126,12 +129,10 @@ def moment_rate_over_time_from_slip(
 
 
 @typing.overload
-def moment_to_magnitude(
-    moment: float, bold_m: typing.Literal[False] = False
-) -> Mw: ...
-@typing.overload
 def moment_to_magnitude(moment: float, bold_m: typing.Literal[True]) -> BoldM: ...
-def moment_to_magnitude(moment: float, bold_m: bool = False) -> Mw | BoldM:
+@typing.overload
+def moment_to_magnitude(moment: float, bold_m: typing.Literal[False] = False) -> Mw: ...
+def moment_to_magnitude(moment: float, bold_m: bool = True) -> BoldM | Mw:
     """Convert moment to magnitude.
 
     NOTE: the qcore mag_scaling module does not have this expression.
@@ -141,45 +142,58 @@ def moment_to_magnitude(moment: float, bold_m: bool = False) -> Mw | BoldM:
     moment : float
         The moment of the rupture in Nm.
     bold_m : bool, optional
-        If True, return the magnitude in BoldM convention
-        (`BoldM = Mw + BOLDM_MW_OFFSET`). Default is False (Mw).
+        Set whether Equation 4 or 7 from [Hanks1979]_ is used for the conversion.
+        If True, use Equation 7 (`BoldM` convention).
+        If False, use Equation 4 (`Mw` convention).
 
     Returns
     -------
-    Mw | BoldM
-        Rupture magnitude in the requested convention.
+    BoldM | Mw
+        Rupture moment magnitude in the convention specified by `bold_m`.
+
+    References
+    ----------
+    .. [Hanks1979] Hanks, T. C., and H. Kanamori (1979),
+           "A moment magnitude scale",
+           J. Geophys. Res., 84(B5), 2348-2350,
+           doi:10.1029/JB084iB05p02348.
     """
-    mw = 2 / 3 * np.log10(moment) - 6.03333
+
     if bold_m:
-        return BoldM(mw + BOLDM_MW_OFFSET)
-    return Mw(mw)
+        return BoldM(2 / 3 * np.log10(moment) - EQUATION_7_COEFFICIENT)
+
+    if not bold_m:
+        return Mw(2 / 3 * np.log10(moment) - EQUATION_4_COEFFICIENT)
 
 
+@typing.overload
+def magnitude_to_moment(magnitude: BoldM, bold_m: typing.Literal[True]) -> float: ...
 @typing.overload
 def magnitude_to_moment(
     magnitude: Mw, bold_m: typing.Literal[False] = False
 ) -> float: ...
-@typing.overload
-def magnitude_to_moment(magnitude: BoldM, bold_m: typing.Literal[True]) -> float: ...
-def magnitude_to_moment(magnitude: Mw | BoldM, bold_m: bool = False) -> float:
+def magnitude_to_moment(magnitude: BoldM | Mw, bold_m: bool = True) -> float:
     """Convert magnitude to moment.
 
     Parameters
     ----------
-    magnitude : Mw | BoldM
+    magnitude : BoldM | Mw
         The magnitude of the rupture, in the convention indicated by `bold_m`.
     bold_m : bool, optional
-        If True, `magnitude` is interpreted as BoldM and converted to Mw
-        (`Mw = BoldM - BOLDM_MW_OFFSET`) before computing the moment.
-        Default is False (input is Mw).
+        Set whether Equation 4 or 7 from [Hanks1979]_ is used for the conversion.
+        If True, use Equation 7 (`BoldM` convention).
+        If False, use Equation 4 (`Mw` convention).
 
     Returns
     -------
     float
         Rupture moment in Nm.
     """
-    mw = magnitude - BOLDM_MW_OFFSET if bold_m else magnitude
-    return 10 ** ((mw + 6.03333) * 3 / 2)
+
+    if bold_m:
+        return 10 ** ((magnitude + EQUATION_7_COEFFICIENT) * 3 / 2)
+    if not bold_m:
+        return 10 ** ((magnitude + EQUATION_4_COEFFICIENT) * 3 / 2)
 
 
 def moment_over_time_from_moment_rate(moment_rate_df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_magnitude_scaling.py
+++ b/tests/test_magnitude_scaling.py
@@ -12,6 +12,7 @@ import scipy as sp
 from hypothesis import assume, given
 
 from source_modelling import magnitude_scaling
+from source_modelling.magnitude_scaling import BoldM, Mw
 
 MAGNITUDE_TO_AREA = {
     magnitude_scaling.ScalingRelation.LEONARD2014: magnitude_scaling.leonard_magnitude_to_area,
@@ -116,7 +117,7 @@ def test_inversion(
     else:
         mag_to_area = MAGNITUDE_TO_AREA[scaling_relation]
         area_to_mag = AREA_TO_MAGNITUDE[scaling_relation]
-    assert area_to_mag(mag_to_area(magnitude)) == pytest.approx(magnitude)  # ty: ignore[missing-argument]
+    assert area_to_mag(mag_to_area(magnitude)) == pytest.approx(magnitude)  # ty: ignore[missing-argument, invalid-argument-type]
 
 
 @pytest.mark.parametrize(
@@ -149,7 +150,7 @@ def test_inversion(
         (9.0, 180.0, 102329.29922807537),
     ],
 )
-def test_leonard_area(mw: float, rake: float, expected_area: float):
+def test_leonard_area(mw: Mw, rake: float, expected_area: float):
     """Test the Leonard 2014 area calculation against values from the old implementation in qcore.
 
     NOTE: this combined with the inversion test for leonard ensure that the area calculation is compatible with the old implementation as well."""
@@ -213,7 +214,7 @@ def test_leonard_area(mw: float, rake: float, expected_area: float):
         (7.8, 5211.947111050806),
     ],
 )
-def test_strasser_slab_expected_area(mw: float, expected_area: float):
+def test_strasser_slab_expected_area(mw: BoldM, expected_area: float):
     """Test the Strasser 2010 slab area calculation against values from the old implementation in qcore."""
     assert magnitude_scaling.strasser_slab_magnitude_to_area(mw) == pytest.approx(
         expected_area
@@ -221,8 +222,8 @@ def test_strasser_slab_expected_area(mw: float, expected_area: float):
 
 
 @given(st.floats(min_value=5.9, max_value=7.7))
-def test_strasser_monotonicity(mag1: float):
-    mag2 = mag1 + 0.1  # Slightly higher magnitude
+def test_strasser_monotonicity(mag1: BoldM):
+    mag2 = BoldM(mag1 + 0.1)  # Slightly higher magnitude
     assert magnitude_scaling.strasser_slab_magnitude_to_area(
         mag2
     ) > magnitude_scaling.strasser_slab_magnitude_to_area(mag1)
@@ -245,7 +246,7 @@ def test_monotonicity_mag_to_area(
         mag_to_area = functools.partial(MAGNITUDE_TO_AREA[scaling_relation], rake=rake)  # ty: ignore[unknown-argument, invalid-argument-type]
     else:
         mag_to_area = MAGNITUDE_TO_AREA[scaling_relation]
-    assert mag_to_area(magnitude + 0.1) > mag_to_area(magnitude)  # ty: ignore[missing-argument]
+    assert mag_to_area(magnitude + 0.1) > mag_to_area(magnitude)  # ty: ignore[missing-argument, invalid-argument-type]
 
 
 class RandomFunction(Protocol):
@@ -260,8 +261,8 @@ class RandomFunction(Protocol):
         itertools.product(
             [magnitude_scaling.contreras_interface_area_to_magnitude],
             np.linspace(
-                magnitude_scaling.contreras_interface_magnitude_to_area(6.0),
-                magnitude_scaling.contreras_interface_magnitude_to_area(9.0),
+                magnitude_scaling.contreras_interface_magnitude_to_area(BoldM(6.0)),
+                magnitude_scaling.contreras_interface_magnitude_to_area(BoldM(9.0)),
                 10,
             ),
         )
@@ -485,7 +486,7 @@ def test_area_preservation_lw(
 )
 def test_area_preservation_lw_leonard(
     rake: float,
-    magnitude: float,
+    magnitude: Mw,
 ):
     """Test that the area is preserved when converting between area and length/width."""
     area = magnitude_scaling.leonard_magnitude_to_area(magnitude, rake)
@@ -534,7 +535,7 @@ def test_magnitude_to_length_width_calls_correct_function(
     func_name: str,
     rake_required: bool,
 ):
-    magnitude = 7.0
+    magnitude = Mw(7.0)
     rake = 90.0 if rake_required else None
     random = True
 
@@ -573,7 +574,7 @@ def test_magnitude_to_area_calls_correct_function(
     func_name: str,
     rake_required: bool,
 ):
-    magnitude = 7.0
+    magnitude = Mw(7.0)
     rake = 90.0 if rake_required else None
     random = True
 

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -9,6 +9,7 @@ from hypothesis import strategies as st
 from hypothesis.extra import numpy as nst
 
 from source_modelling import moment
+from source_modelling.magnitude_scaling import Mw
 from source_modelling.sources import Fault, Plane
 
 
@@ -190,7 +191,7 @@ def test_point_source_slip_bad_dataframe():
         }
     )
 
-    moment_newton_metre = moment.magnitude_to_moment(5.0)
+    moment_newton_metre = moment.magnitude_to_moment(Mw(5.0))
 
     # Should raise KeyError when trying to access missing columns
     with pytest.raises(KeyError):


### PR DESCRIPTION
The scaling relationships and moment conversions in `source_modelling` mix two distinct moment magnitude conventions, `Mw` and `BoldM` (where `BoldM = Mw + 0.0333`), but previously typed everything as a plain `float`, making it easy to pass a magnitude in the wrong convention. This PR implements Jake's suggestion of encoding the convention in the type system so each relationship documents and checks via type checkers which one it expects.
