### PR TITLE
Set version correctly

### DIFF
--- a/.github/workflows/publish-PyPI.yml
+++ b/.github/workflows/publish-PyPI.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.0
         with:
           ref: ${{ inputs.tag_name || github.ref }}
           fetch-depth: 0


### PR DESCRIPTION
Correctly set the cibuildwheel version, v4 is not a tag on the repo so GH actions can't find it.