### PR TITLE
Small change to support writing version 2 SRFs for point sources

### DIFF
--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -304,6 +304,55 @@ def dyne_cm_to_newton_metre(dyne_cm: float) -> float:
     return dyne_cm * _dyne_to_newton * _cm_to_m
 
 
+@typing.overload
+def velocity_model_layer_index(
+    velocity_model_df: pd.DataFrame, depths_km: float
+) -> np.intp: ...  # numpydoc ignore=GL08
+@typing.overload
+def velocity_model_layer_index(
+    velocity_model_df: pd.DataFrame, depths_km: npt.NDArray[np.floating]
+) -> npt.NDArray[np.intp]: ...  # numpydoc ignore=GL08
+def velocity_model_layer_index(
+    velocity_model_df: pd.DataFrame, depths_km: float | npt.NDArray[np.floating]
+) -> np.intp | npt.NDArray[np.intp]:
+    """Return the velocity-model layer index containing each depth.
+
+    Selects the deepest layer whose top depth does not exceed the query depth (a depth
+    exactly on a layer boundary takes the deeper layer); a depth above the first layer top
+    clamps to layer 0. Scalar in -> scalar out; array in -> array out.
+
+    Parameters
+    ----------
+    velocity_model_df : pd.DataFrame
+        Velocity model with a ``depth_km`` column of layer *top* depths in kilometres, the
+        first of which must be 0.
+    depths_km : float or npt.NDArray[np.floating]
+        Query depth(s) in kilometres.
+
+    Returns
+    -------
+    np.intp or npt.NDArray[np.intp]
+        The layer index for each query depth.
+
+    Raises
+    ------
+    ValueError
+        If the velocity model does not begin at 0 km depth (a sign that bottom depths were
+        passed instead of top depths).
+    """
+    if not np.isclose(velocity_model_df["depth_km"].iloc[0], 0.0):
+        raise ValueError(
+            "Velocity model does not begin at 0km depth (are you using bottom depth instead of top depth)?"
+        )
+    return np.maximum(
+        np.searchsorted(
+            velocity_model_df["depth_km"].to_numpy(), depths_km, side="right"
+        )
+        - 1,
+        0,
+    )
+
+
 def point_source_slip(
     moment_newton_metre: float,
     fault_area_km2: float,
@@ -335,21 +384,7 @@ def point_source_slip(
         The calculated slip in cm.
     """
 
-    # While this is not strictly necessary, it does act as a sanity check to
-    # ensure that the bug does not reoccur in the future.
-    if not np.isclose(velocity_model_df["depth_km"].iloc[0], 0.0):
-        raise ValueError(
-            "Velocity model does not begin at 0km depth (are you using bottom depth instead of top depth)?"
-        )
-    # Finds the first index i in the velocity model such that depth[i] <= source depth < depth[i + 1]
-    # At a boundary therefore, it returns the bottom-most layer index instead of the top.
-    idx = (
-        np.searchsorted(
-            velocity_model_df["depth_km"].to_numpy(), source_depth_km, side="right"
-        )
-        - 1
-    )
-    idx = max(0, idx)
+    idx = velocity_model_layer_index(velocity_model_df, source_depth_km)
     vs_km_per_s = velocity_model_df.iloc[idx]["Vs"]
     rho_g_per_cm3 = velocity_model_df.iloc[idx]["rho"]
 

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -340,26 +340,6 @@ def velocity_model_layer_index(
         If the velocity model does not begin at 0 km depth (a sign that bottom depths were
         passed instead of top depths).
 
-    Notes
-    -----
-    Layers are keyed by their *top* depths ``t0 = 0 < t1 < ... < tN`` (the ``depth_km``
-    column). Each layer covers ``t_i <= depth < t_(i+1)``, so a depth lying exactly on a
-    boundary belongs to the *deeper* layer (the one whose top it is), and the deepest
-    layer is unbounded::
-
-        depth                          returned index
-        -----                          --------------
-        t0 = 0  --+--  layer 0          0   for  t0 <= depth < t1   (t0 = 0)
-                  |
-        t1      --+--  layer 1          1   for  t1 <= depth < t2   (depth == t1 -> 1)
-                  |
-        t2      --+--  layer 2          2   for  t2 <= depth < t3   (depth == t2 -> 2)
-                  |
-                  :     ...
-                  |
-        tN      --+--  layer N          N   for  depth >= tN        (deepest, unbounded)
-
-    Equivalently, ``searchsorted(depth_km, depth, side="right") - 1`` clamped at 0.
     """
     if not np.isclose(velocity_model_df["depth_km"].iloc[0], 0.0):
         raise ValueError(

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -339,6 +339,27 @@ def velocity_model_layer_index(
     ValueError
         If the velocity model does not begin at 0 km depth (a sign that bottom depths were
         passed instead of top depths).
+
+    Notes
+    -----
+    Layers are keyed by their *top* depths ``t0 = 0 < t1 < ... < tN`` (the ``depth_km``
+    column). Each layer covers ``t_i <= depth < t_(i+1)``, so a depth lying exactly on a
+    boundary belongs to the *deeper* layer (the one whose top it is), and the deepest
+    layer is unbounded::
+
+        depth                          returned index
+        -----                          --------------
+        t0 = 0  --+--  layer 0          0   for  t0 <= depth < t1   (t0 = 0)
+                  |
+        t1      --+--  layer 1          1   for  t1 <= depth < t2   (depth == t1 -> 1)
+                  |
+        t2      --+--  layer 2          2   for  t2 <= depth < t3   (depth == t2 -> 2)
+                  |
+                  :     ...
+                  |
+        tN      --+--  layer N          N   for  depth >= tN        (deepest, unbounded)
+
+    Equivalently, ``searchsorted(depth_km, depth, side="right") - 1`` clamped at 0.
     """
     if not np.isclose(velocity_model_df["depth_km"].iloc[0], 0.0):
         raise ValueError(

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -344,13 +344,18 @@ def velocity_model_layer_index(
         raise ValueError(
             "Velocity model does not begin at 0km depth (are you using bottom depth instead of top depth)?"
         )
-    return np.maximum(
+
+    idx = (
         np.searchsorted(
             velocity_model_df["depth_km"].to_numpy(), depths_km, side="right"
         )
-        - 1,
-        0,
+        - 1
     )
+
+    if isinstance(depths_km, (int, float, np.floating)):
+        return max(0, int(idx))
+
+    return np.maximum(0, idx)
 
 
 def point_source_slip(

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -307,14 +307,14 @@ def dyne_cm_to_newton_metre(dyne_cm: float) -> float:
 @typing.overload
 def velocity_model_layer_index(
     velocity_model_df: pd.DataFrame, depths_km: float
-) -> np.intp: ...  # numpydoc ignore=GL08
+) -> int: ...  # numpydoc ignore=GL08
 @typing.overload
 def velocity_model_layer_index(
     velocity_model_df: pd.DataFrame, depths_km: npt.NDArray[np.floating]
 ) -> npt.NDArray[np.intp]: ...  # numpydoc ignore=GL08
 def velocity_model_layer_index(
     velocity_model_df: pd.DataFrame, depths_km: float | npt.NDArray[np.floating]
-) -> np.intp | npt.NDArray[np.intp]:
+) -> int | npt.NDArray[np.intp]:
     """Return the velocity-model layer index containing each depth.
 
     Selects the deepest layer whose top depth does not exceed the query depth. A depth

--- a/source_modelling/moment.py
+++ b/source_modelling/moment.py
@@ -317,9 +317,8 @@ def velocity_model_layer_index(
 ) -> np.intp | npt.NDArray[np.intp]:
     """Return the velocity-model layer index containing each depth.
 
-    Selects the deepest layer whose top depth does not exceed the query depth (a depth
-    exactly on a layer boundary takes the deeper layer); a depth above the first layer top
-    clamps to layer 0. Scalar in -> scalar out; array in -> array out.
+    Selects the deepest layer whose top depth does not exceed the query depth. A depth
+    exactly on a layer boundary takes the deeper layer.
 
     Parameters
     ----------

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -209,3 +209,28 @@ def test_point_source_slip_bad_dataframe():
             velocity_model_df=bad_velocity_model_df,
             source_depth_km=2.0,
         )
+
+
+def test_velocity_model_layer_index():
+    """Deepest layer whose top <= depth; boundary -> deeper; clamp at ends."""
+    vm = pd.DataFrame({"depth_km": [0.0, 1.0, 2.0]})
+
+    assert moment.velocity_model_layer_index(vm, 0.0) == 0
+    assert moment.velocity_model_layer_index(vm, 0.5) == 0
+    assert moment.velocity_model_layer_index(vm, 1.0) == 1  # boundary -> deeper layer
+    assert moment.velocity_model_layer_index(vm, 1.5) == 1
+    assert (
+        moment.velocity_model_layer_index(vm, 5.0) == 2
+    )  # below last top -> last layer
+
+    np.testing.assert_array_equal(
+        moment.velocity_model_layer_index(vm, np.array([0.0, 1.0, 1.5, 2.0, 5.0])),
+        np.array([0, 1, 1, 2, 2]),
+    )
+
+
+def test_velocity_model_layer_index_top_depth():
+    """A velocity model not beginning at 0 km depth raises."""
+    bad_vm = pd.DataFrame({"depth_km": [1.0, 2.0]})
+    with pytest.raises(ValueError, match="Velocity model does not begin at 0km depth"):
+        moment.velocity_model_layer_index(bad_vm, 1.0)

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -245,8 +245,8 @@ def test_velocity_model_layer_index():
     )
     np.testing.assert_array_equal(array_result, np.array([0, 1, 1, 2, 2]))
 
-    # Lock the overload type contract: scalar input -> np.intp, array input -> np.intp array.
-    assert isinstance(moment.velocity_model_layer_index(vm, 0.5), np.intp)
+    # Lock the overload type contract: scalar input -> int, array input -> np.intp array.
+    assert isinstance(moment.velocity_model_layer_index(vm, 0.5), int)
     assert array_result.dtype == np.intp
 
 

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -223,10 +223,14 @@ def test_velocity_model_layer_index():
         moment.velocity_model_layer_index(vm, 5.0) == 2
     )  # below last top -> last layer
 
-    np.testing.assert_array_equal(
-        moment.velocity_model_layer_index(vm, np.array([0.0, 1.0, 1.5, 2.0, 5.0])),
-        np.array([0, 1, 1, 2, 2]),
+    array_result = moment.velocity_model_layer_index(
+        vm, np.array([0.0, 1.0, 1.5, 2.0, 5.0])
     )
+    np.testing.assert_array_equal(array_result, np.array([0, 1, 1, 2, 2]))
+
+    # Lock the overload type contract: scalar input -> np.intp, array input -> np.intp array.
+    assert isinstance(moment.velocity_model_layer_index(vm, 0.5), np.intp)
+    assert array_result.dtype == np.intp
 
 
 def test_velocity_model_layer_index_top_depth():

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -212,9 +212,26 @@ def test_point_source_slip_bad_dataframe():
 
 
 def test_velocity_model_layer_index():
-    """Deepest layer whose top <= depth; boundary -> deeper; clamp at ends."""
+    """Test depth-to-velocity-layer mapping.
+
+    With layer top depths ``[0, 1, 2]`` km (three layers, the deepest unbounded), each
+    query depth is assigned the deepest layer whose top does not exceed it:
+
+    - an interior depth lands in its containing layer (``0.5 -> 0``, ``1.5 -> 1``);
+    - a depth exactly on a layer boundary takes the deeper layer, i.e. the one whose top
+      it is (``0.0 -> 0``, ``1.0 -> 1``, ``2.0 -> 2``);
+    - a depth beyond the last layer top falls in the deepest, unbounded layer
+      (``5.0 -> 2``);
+    - a depth above the surface (necessarily negative, as the model starts at 0) is
+      clamped to layer 0 rather than wrapping to the last layer (``-1.0 -> 0``);
+    - a scalar input returns an ``np.intp`` and an array input returns an ``np.intp``
+      array.
+    """
     vm = pd.DataFrame({"depth_km": [0.0, 1.0, 2.0]})
 
+    assert (
+        moment.velocity_model_layer_index(vm, -1.0) == 0
+    )  # above surface -> clamp to 0
     assert moment.velocity_model_layer_index(vm, 0.0) == 0
     assert moment.velocity_model_layer_index(vm, 0.5) == 0
     assert moment.velocity_model_layer_index(vm, 1.0) == 1  # boundary -> deeper layer
@@ -233,7 +250,7 @@ def test_velocity_model_layer_index():
     assert array_result.dtype == np.intp
 
 
-def test_velocity_model_layer_index_top_depth():
+def test_velocity_model_must_start_at_zero():
     """A velocity model not beginning at 0 km depth raises."""
     bad_vm = pd.DataFrame({"depth_km": [1.0, 2.0]})
     with pytest.raises(ValueError, match="Velocity model does not begin at 0km depth"):


### PR DESCRIPTION
This PR just pulls the depth-to-velocity-model-layer mapping into a function (instead of inline as before) so that it can be called by the workflow to write version 2 SRFs for point sources ([this PR](https://github.com/ucgmsim/workflow/pull/120)). The basic change is very small but the number of new lines has grown due to new tests and an ASCII art diagram I asked Claude to make, mostly as an experiment. I'm happy to delete those if you prefer.