### PR TITLE
Read all POINTS blocks in multi-segment SRFs

### DIFF
--- a/source_modelling/srf.py
+++ b/source_modelling/srf.py
@@ -38,6 +38,7 @@ Examples
 """
 
 import dataclasses
+import mmap
 import re
 from collections.abc import Sequence
 from pathlib import Path
@@ -96,6 +97,98 @@ SW4_POINTS_DTYPE = np.dtype(
 )
 
 _SW4_POINTS_EXTERNAL_FIELDS = {"VS", "DEN", "NT1", "SLIP2", "NT2", "SLIP3", "NT3"}
+
+
+def _find_point_blocks(srf_ffp: Path | str, start: int) -> list[tuple[int, int]]:
+    """Locate every ``POINTS`` block in an SRF file.
+
+    A single-segment (or otherwise concatenated) SRF has one ``POINTS`` block
+    holding all subfaults, whereas genslip writes multi-segment ruptures with
+    one ``POINTS`` block per plane. This returns each block so the reader can
+    consume them all.
+
+    Parameters
+    ----------
+    srf_ffp : Path | str
+        The path to the SRF file.
+    start : int
+        Byte offset to begin scanning from (i.e. the end of the plane
+        headers), so ``POINTS`` tokens inside the leading comment lines are
+        never matched.
+
+    Returns
+    -------
+    list[tuple[int, int]]
+        A ``(data_offset, point_count)`` pair for each ``POINTS`` block, in
+        file order. ``data_offset`` is the byte offset of the first point line
+        (immediately after the ``POINTS N`` header line).
+    """
+    blocks = []
+    with open(srf_ffp, mode="rb") as srf_file_handle:
+        srf_bytes = mmap.mmap(srf_file_handle.fileno(), 0, access=mmap.ACCESS_READ)
+        try:
+            pos = srf_bytes.find(b"POINTS", start)
+            while pos != -1:
+                line_end = srf_bytes.find(b"\n", pos)
+                if line_end == -1:
+                    line_end = len(srf_bytes)
+                # Only treat "POINTS" as a header when it begins a line, so it
+                # cannot be confused with point data or comment text.
+                at_line_start = pos == 0 or srf_bytes[pos - 1 : pos] in (b"\n", b"\r")
+                if at_line_start:
+                    header = srf_bytes[pos:line_end].decode("utf-8", "replace").strip()
+                    match = re.match(POINT_COUNT_RE, header)
+                    if match:
+                        blocks.append((line_end + 1, int(match.group(1))))
+                pos = srf_bytes.find(b"POINTS", line_end + 1)
+        finally:
+            srf_bytes.close()
+    return blocks
+
+
+def _combine_slip_blocks(
+    slip_blocks: list[tuple["sp.sparse.csr_array | None", int]],
+) -> "sp.sparse.csr_array | None":
+    """Vertically stack per-block slip-rate arrays into one array.
+
+    Each block's slip-rate array may have a different number of columns
+    (timesteps), since floor(tinit / dt) + nt differs between segments. Blocks
+    are padded to the widest column count before stacking. Empty blocks (no
+    slip samples) contribute all-zero rows so the row count stays aligned with
+    the points.
+
+    Parameters
+    ----------
+    slip_blocks : list[tuple[csr_array | None, int]]
+        A ``(slip_array, point_count)`` pair per block, in file order. The slip
+        array is ``None`` when the block records no slip samples.
+
+    Returns
+    -------
+    csr_array | None
+        The combined slip-rate array, or ``None`` when no block records any
+        slip.
+    """
+    if all(slip is None for slip, _ in slip_blocks):
+        return None
+    if len(slip_blocks) == 1:
+        return slip_blocks[0][0]
+    max_columns = max(
+        (slip.shape[1] for slip, _ in slip_blocks if slip is not None), default=0
+    )
+    padded = []
+    for slip, point_count in slip_blocks:
+        if slip is None:
+            padded.append(sp.sparse.csr_array((point_count, max_columns)))
+        else:
+            # Re-widen to the common column count; column indices are unchanged.
+            padded.append(
+                sp.sparse.csr_array(
+                    (slip.data, slip.indices, slip.indptr),
+                    shape=(slip.shape[0], max_columns),
+                )
+            )
+    return sp.sparse.csr_array(sp.sparse.vstack(padded, format="csr"))
 
 
 class Segments(Sequence):
@@ -271,18 +364,32 @@ class SrfFile:
             headers["nstk"] = headers["nstk"].astype(int)
             headers["ndip"] = headers["ndip"].astype(int)
 
-            points_count_line = srf_file_handle.readline().strip()
-            points_count_match = re.match(POINT_COUNT_RE, points_count_line)
-            if not points_count_match:
-                raise parse_utils.ParseError(
-                    f'Expecting POINTS header line, got: "{points_count_line}"'
-                )
-            point_count = int(points_count_match.group(1))
-            position = srf_file_handle.tell()
+            # The points section begins here. A rupture stores its subfaults
+            # either in a single POINTS block (all segments concatenated) or,
+            # as genslip writes for multi-segment ruptures, in one POINTS block
+            # per plane. Both layouts are read by consuming every POINTS block.
+            points_section_start = srf_file_handle.tell()
 
-        points_metadata, slipt1_array = srf_parser.parse_srf(  # type: ignore
-            str(srf_ffp), position, point_count, version == "2.0"
+        read_vs_den = version == "2.0"
+        point_blocks = _find_point_blocks(srf_ffp, points_section_start)
+        if not point_blocks:
+            raise parse_utils.ParseError("Expecting POINTS header line, found none")
+
+        metadata_blocks = []
+        slip_blocks = []
+        for data_offset, point_count in point_blocks:
+            points_metadata, slip = srf_parser.parse_srf(  # type: ignore
+                str(srf_ffp), data_offset, point_count, read_vs_den
+            )
+            metadata_blocks.append(points_metadata)
+            slip_blocks.append((slip, point_count))
+
+        points_metadata = (
+            metadata_blocks[0]
+            if len(metadata_blocks) == 1
+            else np.concatenate(metadata_blocks)
         )
+        slipt1_array = _combine_slip_blocks(slip_blocks)
 
         columns = ["lon", "lat", "dep", "stk", "dip", "area", "tinit", "dt"]
         if version == "2.0":

--- a/tests/test_srf.py
+++ b/tests/test_srf.py
@@ -754,3 +754,56 @@ def test_sw4_hdf5_v2(tmp_path: Path):
         points = h5file["POINTS"]
         assert points["VS"] == pytest.approx(srf_v2.points["vs"].to_numpy())
         assert points["DEN"] == pytest.approx(srf_v2.points["den"].to_numpy())
+
+
+def test_read_srf_multiple_point_blocks(tmp_path: Path):
+    """Read a multi-segment SRF that stores one POINTS block per plane.
+
+    genslip writes segmented ruptures with a separate ``POINTS`` block for
+    each plane (rather than a single concatenated block). The reader must
+    consume every block so all segments carry their points. Each plane below
+    holds a single subfault, so the values are hand-verifiable against the
+    file. The two points also start at different times (tinit 0.0 vs 0.2), so
+    their slip-rate functions land in different columns, exercising the
+    combination of per-block sparse slip arrays with differing widths.
+    """
+    srf_ffp = tmp_path / "multi_block.srf"
+    srf_ffp.write_text(
+        "1.0\n"
+        "PLANE 2\n"
+        "  172.0  -43.0   1   1   1.0   1.0\n"
+        "  45   80   0.0   0.0   0.5\n"
+        "  172.5  -43.5   1   1   1.0   1.0\n"
+        "  45   80   0.0   0.0   0.5\n"
+        "POINTS 1\n"
+        "  172.0  -43.0   0.5   45   80   1.0e10   0.0   0.1\n"
+        "  90   10.0   1   0.0   0   0.0   0\n"
+        "  5.0\n"
+        "POINTS 1\n"
+        "  172.5  -43.5   0.6   45   80   1.0e10   0.2   0.1\n"
+        "  90   20.0   1   0.0   0   0.0   0\n"
+        "  7.0\n"
+    )
+    multi_block = srf.read_srf(srf_ffp)
+
+    # Both planes' points must be present, in file order.
+    assert len(multi_block.points) == 2
+    assert multi_block.points["lon"].tolist() == pytest.approx([172.0, 172.5])
+    assert multi_block.points["lat"].tolist() == pytest.approx([-43.0, -43.5])
+    assert multi_block.points["slip"].tolist() == pytest.approx([10.0, 20.0])
+
+    # Each segment must resolve to its own (non-empty) point.
+    assert len(multi_block.segments) == 2
+    assert len(multi_block.segments[0]) == 1
+    assert len(multi_block.segments[1]) == 1
+    assert multi_block.segments[0]["lon"].iloc[0] == pytest.approx(172.0)
+    assert multi_block.segments[1]["lon"].iloc[0] == pytest.approx(172.5)
+
+    # Per-block slip arrays (widths 1 and 3) combine into a single (2, 3) array:
+    # point 0 (floor(0.0/0.1)=0) fills column 0; point 1 (floor(0.2/0.1)=2)
+    # fills column 2.
+    assert multi_block.slipt1_array.shape == (2, 3)
+    assert np.array_equal(
+        multi_block.slipt1_array.toarray(),
+        np.array([[5.0, 0.0, 0.0], [0.0, 0.0, 7.0]], dtype=np.float32),
+    )


### PR DESCRIPTION
## Problem

`read_srf` only read the **first** `POINTS` block of an SRF. For multi-segment
ruptures that genslip writes with **one `POINTS` block per plane** (a single
`PLANE N` header followed by `N` separate `POINTS` blocks), every segment after
the first came back empty.

Consequences of the empty trailing segments:

- Code that assumes `nstk * ndip` points per segment breaks — e.g. `min()`/`max()`
  over an empty segment returns `NaN`. In `visualisation`'s `plot-srf` this
  produced a `nan/nan/nan/nan` plot region and a hard GMT failure
  (`grdlandmask [ERROR]: Grid y increment <= 0.0`).
- Even without an outright crash, ~90% of the rupture's slip was silently
  dropped.

None of the existing SRF fixtures used the per-segment `POINTS`-block layout, so
the case was untested.

## Fix

`read_srf` now discovers **every** `POINTS` block in the points section and
concatenates the results:

- `_find_point_blocks` scans the file (mmap) for each `POINTS N` header and
  returns `(data_offset, count)` per block.
- Each block is parsed with the existing Rust `parse_srf`, then the per-block
  point metadata is concatenated and the per-block slip-rate sparse arrays are
  vertically stacked (`_combine_slip_blocks`), padding to a common column count
  since segments can have different numbers of timesteps.

SRFs that store all points in a single `POINTS` block are read exactly as
before (single-block path is unchanged behaviourally).

## Testing

- New `test_read_srf_multiple_point_blocks`: a hand-verifiable two-segment SRF
  whose points are split across two `POINTS` blocks with differing slip-rate
  widths; asserts all points, per-segment slicing, and the combined
  `(2, 3)` slip array.
- Full suite: **706 passed**, ruff clean.
- Verified end to end against a real 10-segment genslip SRF (108,924 points
  across 10 `POINTS` blocks): all segments now read, and `plot-srf` renders the
  complete rupture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
