### PR TITLE
Add Rust CI Checks

### DIFF
--- a/.github/workflows/deptry.yml
+++ b/.github/workflows/deptry.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Install GMT
         run: sudo apt-get update && sudo apt-get install -y gmt libgmt-dev ghostscript gdal-bin libgdal-dev
 
-      - run: uv run --all-groups deptry .
+      - run: uv run --all-groups --all-extras deptry .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,17 +23,17 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run --all-groups pytest --cov=source_modelling --cov-report=html tests
+          uv run --all-extras pytest --cov=source_modelling --cov-report=html tests
 
       - name: Combine coverage and fail it it’s under 100 %
         run: |
-          uv run --all-groups python -m coverage html --skip-covered --skip-empty
+          uv run --all-extras python -m coverage html --skip-covered --skip-empty
 
           # Report and write to summary.
-          uv run --all-groups python -m coverage report | sed 's/^/    /' >> $GITHUB_STEP_SUMMARY
+          uv run --all-extras python -m coverage report | sed 's/^/    /' >> $GITHUB_STEP_SUMMARY
 
           # Report again and fail if under 95%.
-          uv run --all-groups python -Im coverage report --fail-under=95
+          uv run --all-extras python -Im coverage report --fail-under=95
 
       - name: Upload HTML report if check failed
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,39 @@
+name: Rust Checks
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache Rust build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: cargo test
+        run: cargo test
+
+      - name: cargo doc-tests
+        run: cargo test --doc
+
+      - name: Clippy (Rust linter)
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,8 +32,5 @@ jobs:
       - name: cargo test
         run: cargo test
 
-      - name: cargo doc-tests
-        run: cargo test --doc
-
       - name: Clippy (Rust linter)
         run: cargo clippy -- -D warnings

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -26,4 +26,4 @@ jobs:
           enable-cache: true
 
       - name: Run type checking with ty
-        run: uv run --all-groups ty check --exclude source_modelling/ccldpy.py --exclude setup.py
+        run: uv run --all-groups --all-extras ty check --exclude source_modelling/ccldpy.py --exclude setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "xarray[io]",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 test = [
   "pytest",
   "pytest-cov",
@@ -38,8 +38,9 @@ types = [
   "scipy-stubs",
   "pandas-stubs",
   "types-networkx",
-  "ty",
 ]
+
+[dependency-groups]
 dev = ["ruff", "deptry", "ty", "numpydoc"]
 
 
@@ -141,3 +142,7 @@ cache-keys = [
   { file = "Cargo.toml" },
   { file = "**/*.rs" },
 ]
+
+
+[tool.deptry]
+optional_dependencies_dev_groups = ["test", "types"]

--- a/uv.lock
+++ b/uv.lock
@@ -2158,13 +2158,7 @@ dependencies = [
     { name = "xarray", extra = ["io"] },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "deptry" },
-    { name = "numpydoc" },
-    { name = "ruff" },
-    { name = "ty" },
-]
+[package.optional-dependencies]
 test = [
     { name = "coverage" },
     { name = "hypothesis", extra = ["numpy", "pandas"] },
@@ -2175,27 +2169,45 @@ test = [
 types = [
     { name = "pandas-stubs" },
     { name = "scipy-stubs" },
-    { name = "ty" },
     { name = "types-geopandas" },
     { name = "types-networkx" },
     { name = "types-shapely" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "deptry" },
+    { name = "numpydoc" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "coverage", extras = ["toml"], marker = "extra == 'test'" },
     { name = "fiona" },
     { name = "geopandas" },
     { name = "h5py" },
+    { name = "hypothesis", extras = ["numpy", "pandas"], marker = "extra == 'test'" },
+    { name = "hypothesis-networkx", marker = "extra == 'test'" },
     { name = "networkx" },
     { name = "numba", specifier = ">=0.65.1" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "pandas" },
+    { name = "pandas-stubs", marker = "extra == 'types'" },
     { name = "parse" },
+    { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "qcore-utils" },
     { name = "scipy" },
+    { name = "scipy-stubs", marker = "extra == 'types'" },
     { name = "shapely" },
+    { name = "types-geopandas", marker = "extra == 'types'" },
+    { name = "types-networkx", marker = "extra == 'types'" },
+    { name = "types-shapely", marker = "extra == 'types'" },
     { name = "xarray", extras = ["io"] },
 ]
+provides-extras = ["test", "types"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2203,21 +2215,6 @@ dev = [
     { name = "numpydoc" },
     { name = "ruff" },
     { name = "ty" },
-]
-test = [
-    { name = "coverage", extras = ["toml"] },
-    { name = "hypothesis", extras = ["pandas", "numpy"] },
-    { name = "hypothesis-networkx" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-types = [
-    { name = "pandas-stubs" },
-    { name = "scipy-stubs" },
-    { name = "ty" },
-    { name = "types-geopandas" },
-    { name = "types-networkx" },
-    { name = "types-shapely" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds clippy and cargo tests to the suite of rust CI checks to run on every pull request. In the process I noticed that the split between optional dependencies and dependency groups was wrong and fixed it. For future:

- **Dependency groups** :: Are for tools that aren't required for any code to run. These are dev tools basically.
- **Optional dependencies** :: Are for dependencies that provide functionality for source code but aren't essential for the code to run. These are things like type stubs and test dependencies, or heavy optional dependencies.